### PR TITLE
DESI spectra

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ Redrock change log
 0.4.1 (unreleased)
 ------------------
 
-* No changes yet
+* add suport for new DESI spectra format
 
 0.4 (2017-02-03)
 ----------------

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -19,7 +19,7 @@ from .. import Spectrum
 def write_zbest(outfile, zbest):
     '''
     Write zbest Table to outfile
-    
+
     Adds blank BRICKNAME and SUBTYPE columns if needed
     Adds zbest.meta['EXTNAME'] = 'ZBEST'
     '''
@@ -33,13 +33,75 @@ def write_zbest(outfile, zbest):
     zbest.meta['EXTNAME'] = 'ZBEST'
     zbest.write(outfile, overwrite=True)
 
+def read_spectra(spectrafiles, targetids=None):
+    '''
+    Read targets from a list of spectra files
+
+    Args:
+        spectrafiles : list of input spectra files, or string glob to match
+
+    Returns list of Target objects
+    '''
+    if isinstance(spectrafiles, basestring):
+        import glob
+        spectrafiles = glob.glob(spectrafiles)
+
+    assert len(spectrafiles) > 0
+
+    input_spectra = list()
+    input_targetids = set()
+
+    #- Ignore warnings about zdc2 bricks lacking bricknames in header
+    for infile in spectrafiles:
+        sp = desispec.io.read_spectra(infile)
+        input_spectra.append(sp)
+        input_targetids.update(sp.fmap['TARGETID'])
+
+    if targetids is None:
+        targetids = input_targetids
+
+    targets = list()
+    for targetid in targetids:
+        spectra = list()
+        for sp in input_spectra:
+            for x in sp.bands:          #- typically 'b', 'r', 'z'
+                wave = sp.wave[x]
+                ii = (sp.fmap['TARGETID'] == targetid)
+                flux = sp.flux[x][ii]
+                ivar = sp.ivar[x][ii]
+                Rdata = sp.resolution_data[x][ii]
+
+                #- work around desispec.io.Brick returning 32-bit non-native endian
+                # flux = flux.astype(float)
+                # ivar = ivar.astype(float)
+                # Rdata = Rdata.astype(float)
+
+                for i in range(flux.shape[0]):
+                    if np.all(flux[i] == 0):
+                        # print('WARNING: Skipping spectrum {} of target {} on brick {} with flux=0'.format(i, targetid, brick.brickname))
+                        continue
+
+                    if np.all(ivar[i] == 0):
+                        # print('WARNING: Skipping spectrum {} of target {} on brick {} with ivar=0'.format(i, targetid, brick.brickname))
+                        continue
+
+                    R = Resolution(Rdata[i])
+                    spectra.append(Spectrum(wave, flux[i], ivar[i], R))
+
+        if len(spectra) > 0:
+            targets.append(Target(targetid, spectra))
+        else:
+            print('ERROR: Target {} on {} has no good spectra'.format(targetid, os.path.basename(brickfiles[0])))
+
+    return targets
+
 def read_bricks(brickfiles, trueflux=False, targetids=None):
     '''
     Read targets from a list of brickfiles
-    
+
     Args:
         brickfiles : list of input brick files, or string glob to match
-        
+
     Returns list of Target objects
 
     Note: these don't actually have to be bricks anymore; they are read via
@@ -94,7 +156,7 @@ def read_bricks(brickfiles, trueflux=False, targetids=None):
             targets.append(Target(targetid, spectra))
         else:
             print('ERROR: Target {} on {} has no good spectra'.format(targetid, os.path.basename(brickfiles[0])))
-    
+
     return targets
 
 def rrdesi(options=None):
@@ -102,7 +164,7 @@ def rrdesi(options=None):
     import optparse
     from astropy.io import fits
 
-    parser = optparse.OptionParser(usage = "%prog [options] brickfile1 brickfile2...")
+    parser = optparse.OptionParser(usage = "%prog [options] spectra1 spectra2...")
     parser.add_option("-t", "--templates", type="string",  help="template file or directory")
     parser.add_option("-o", "--output", type="string",  help="output file")
     parser.add_option("--zbest", type="string",  help="output zbest fits file")
@@ -112,21 +174,25 @@ def rrdesi(options=None):
     parser.add_option("--debug", help="debug with ipython", action="store_true")
     ### parser.add_option("--coadd", help="use coadd instead of individual spectra", action="store_true")
     parser.add_option("--allspec", help="use individual spectra instead of coadd", action="store_true")
+    parser.add_option("--bricks", help="inputs are old brick format instead of spectra format", action="store_true")
 
     if options is None:
-        opts, brickfiles = parser.parse_args()
+        opts, infiles = parser.parse_args()
     else:
-        opts, brickfiles = parser.parse_args(options)
+        opts, infiles = parser.parse_args(options)
 
     if (opts.output is None) and (opts.zbest is None):
         print('ERROR: --output or --zbest required')
         sys.exit(1)
 
-    if len(brickfiles) == 0:
-        print('ERROR: must provide input brick files')
+    if len(infiles) == 0:
+        print('ERROR: must provide input spectra/brick files')
         sys.exit(1)
 
-    targets = read_bricks(brickfiles)
+    if bricks:
+        targets = read_bricks(infiles)
+    else:
+        targets = read_spectra(infiles)
 
     if not opts.allspec:
         for t in targets:

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -189,7 +189,7 @@ def rrdesi(options=None):
         print('ERROR: must provide input spectra/brick files')
         sys.exit(1)
 
-    if bricks:
+    if opts.bricks:
         targets = read_bricks(infiles)
     else:
         targets = read_spectra(infiles)


### PR DESCRIPTION
This PR adds support to redrock for the new DESI spectra format (brz all in one file), while still supporting the older brick file format (brz in separate files).  It includes the propagation of BRICKNAME from the input files while recognizing that now multiple BRICKNAMEs could be present in a single spectra file (previously it required that all targets in a file corresponded to the same BRICKNAME).

Will self merge momentarily so that I can tag and install at NERSC.