### PR TITLE
shared memory refactor

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ Redrock change log
 0.4.2 (unreleased)
 ------------------
 
-* No changes yet
+* refactored multiprocessing parallelism to use explicit shared memory
 
 0.4.1 (2017-06-16)
 ------------------

--- a/py/redrock/dataobj.py
+++ b/py/redrock/dataobj.py
@@ -89,7 +89,10 @@ class Spectrum(object):
         self.wavehash = hash((len(wave), wave[0], wave[1], wave[-2], wave[-1]))
 
     def sharedmem_unpack(self):
-        '''TODO: document'''
+        '''Unpack shared memory buffers back into numpy array views of those
+        buffers; to be called after self.sharedmem_pack() to restore the object
+        back to a working state (as opposed to a state optimized for sending
+        to a new process).'''
         self.wave = sharedmem.toarray(self._shmem['wave'])
         self.flux = sharedmem.toarray(self._shmem['flux'])
         self.ivar = sharedmem.toarray(self._shmem['ivar'])
@@ -102,7 +105,7 @@ class Spectrum(object):
     def sharedmem_pack(self):
         '''
         Prepare for passing to multiprocessing process function;
-        use self.sharedmem_unpack() to restore to the original state
+        use self.sharedmem_unpack() to restore to the original state.
         '''
         if hasattr(self, 'wave'):
             del self.wave
@@ -164,7 +167,8 @@ class Target(object):
             self.coadd.append(Spectrum(wave, flux, weights, R))
 
     def sharedmem_pack(self):
-        '''TODO: document'''
+        '''Prepare underlying numpy arrays for sending to a new process;
+        call self.sharedmem_unpack() to restore to original state.'''
         for s in self.spectra:
             s.sharedmem_pack()
 
@@ -173,7 +177,9 @@ class Target(object):
                 s.sharedmem_pack()
 
     def sharedmem_unpack(self):
-        '''TODO: document'''
+        '''Unpack shared memory arrays into numpy array views of them.
+        To be used after self.sharedmem_pack() was called to pack arrays
+        before passing them to a new process.'''
         for s in self.spectra:
             s.sharedmem_unpack()
 

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -197,6 +197,8 @@ def rrdesi(options=None):
     import redrock
     import optparse
     from astropy.io import fits
+    import time
+    start_time = time.time()
 
     parser = optparse.OptionParser(usage = "%prog [options] spectra1 spectra2...")
     parser.add_option("-t", "--templates", type="string",  help="template file or directory")
@@ -261,6 +263,9 @@ def rrdesi(options=None):
 
         print('INFO: writing {}'.format(opts.zbest))
         write_zbest(opts.zbest, zbest)
+
+    run_time = time.time() - start_time
+    print('INFO: finished {} in {:.1f} seconds'.format(os.path.basename(infiles[0]), run_time))
 
     if opts.debug:
         import IPython

--- a/py/redrock/fitz.py
+++ b/py/redrock/fitz.py
@@ -72,9 +72,11 @@ def _wrap_fitz(target_indices, qout, zchi2, redshifts, targets, template, nminim
 
     qout.close()
 
-def parallel_fitz_targets(zchi2, redshifts, targets, template, nminima=3, ncpu=None, verbose=False):
+def parallel_fitz_targets(zchi2, redshifts, targets, template, nminima=3, ncpu=None):
     '''
-    TODO: document
+    run `fitz` in parallel using `ncpu` CPU cores.
+
+    See fitz for inputs and outputs.
     '''
     assert zchi2.shape == (len(targets), len(redshifts))
 
@@ -135,7 +137,7 @@ def parallel_fitz_targets(zchi2, redshifts, targets, template, nminima=3, ncpu=N
 def fitz(zchi2, redshifts, spectra, template, nminima=3):
     '''Refines redshift measurement around up to nminima minima
 
-    TODO: document return values
+    TODO: document return values    
     TODO: if there are fewer than nminima minima, consider padding
     '''
     assert len(zchi2) == len(redshifts)

--- a/py/redrock/sharedmem.py
+++ b/py/redrock/sharedmem.py
@@ -1,0 +1,41 @@
+'''
+Utilities for working with multiprocessing shared memory arrays
+
+Copy a numpy array into a shared memory tuple::
+
+    raw = sharedmem.fromarray(np.arange(1000))
+
+`raw` can be passed to a separate multiprocessing process with minimal
+pickling and memory overhead, and then converted back into a numpy ndarray::
+
+    x = sharedmem.toarray(raw)
+
+Writing to x will change the shared buffer for all processes, but this does
+not provide any locking mechanism.  In general this is intended for large
+read-only inputs.
+'''
+
+import numpy as np
+import multiprocessing as mp
+
+def fromarray(x):
+    '''
+    Copies array `x` into a shared memory buffer
+
+    Returns `raw` tuple of information for `y = toarray(shmem)`
+
+    Note: this copies the contents of `x`; it does *not* convert `x` itself
+    into a shared memory array
+    '''
+    x = np.asarray(x)
+    rawbuf = mp.RawArray(x.dtype.char, x.size)
+    a = np.frombuffer(rawbuf, dtype=x.dtype).reshape(x.shape)
+    a[:] = x
+    return (rawbuf, x.dtype, x.shape)
+
+def toarray(raw):
+    '''
+    Generate a numpy.ndarray with info from sharedmem.fromarray(x)
+    '''
+    rawbuf, dtype, shape = raw
+    return np.frombuffer(rawbuf, dtype=dtype).reshape(shape)

--- a/py/redrock/test/util.py
+++ b/py/redrock/test/util.py
@@ -33,6 +33,8 @@ def get_target(z=0.5, wavestep=5):
         sigma = np.random.normal(loc=1, scale=0.1, size=len(wave)).clip(0.5, 1.5)
         ivar = 1/sigma**2
         R = _getR(len(wave), 2.0)
+        assert isinstance(R, scipy.sparse.dia_matrix)
+        assert hasattr(R, 'offsets')
         for i in range(2):
             noisyflux = flux + np.random.normal(scale=sigma)
             spectra.append(Spectrum(wave, noisyflux, ivar, R))

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -79,7 +79,7 @@ def zfind(targets, templates, ncpu=None, nminima=3):
         ### print('DEBUG: PID {} Starting fitz for {}'.format(pid, t.fulltype))
         for i, zfit in enumerate(redrock.fitz.parallel_fitz_targets(
                 zchi2+penalty, t.redshifts, targets, t,
-                ncpu=ncpu, verbose=False, nminima=nminima)):
+                ncpu=ncpu, nminima=nminima)):
             zscan[targets[i].id][t.fulltype]['zfit'] = zfit
         
         for i in range(len(targets)):

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -10,7 +10,13 @@ import redrock
 
 def calc_zchi2(redshifts, spectra, template):
     '''
-    TODO: document
+    Calculates chi2 vs. redshift for these spectra and this template.
+
+    returns chi2[nz], coeff[nz,ncoeff], penalty[nz]
+
+    `chi2[i]` is best fit chi2 at `redshifts[i]`.
+    `coeff[i]` is array of best fit template coefficients at `redshifts[i]`.
+    `penalty` is array of penalty priors, e.g. to penalize unphysical fits.
     '''
     targets = [Target(0, spectra), ]
     zchi2, zcoeff, penalty = calc_zchi2_targets(redshifts, targets, template)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup_keywords['description'] = 'Redrock redshift fitter'
 setup_keywords['author'] = 'Stephen Bailey'
 setup_keywords['author_email'] = 'StephenBailey@lbl.gov'
 setup_keywords['license'] = 'BSD'
-setup_keywords['url'] = 'https://github.com/sbailey/redrock'
+setup_keywords['url'] = 'https://github.com/desihub/redrock'
 #
 # END OF SETTINGS THAT NEED TO BE CHANGED.
 #
@@ -38,7 +38,7 @@ except ImportError:
             setup_keywords['long_description'] = readme.read()
     else:
         setup_keywords['long_description'] = ''
-    setup_keywords['version'] = '0.2.dev1'
+    setup_keywords['version'] = 'unknown'
 #
 # Indicates if this version is a release version.
 #
@@ -64,7 +64,7 @@ if os.path.isdir('bin'):
 setup_keywords['provides'] = [setup_keywords['name']]
 setup_keywords['requires'] = ['Python (>2.7.0)']
 setup_keywords['zip_safe'] = False
-setup_keywords['use_2to3'] = True
+setup_keywords['use_2to3'] = False
 setup_keywords['packages'] = find_packages('py')
 setup_keywords['package_dir'] = {'':'py'}
 setup_keywords['test_suite'] = 'redrock.test.test_suite'


### PR DESCRIPTION
This PR refactors the multiprocessing parallelism to explicitly use shared memory rather than relying upon os.fork() to share global state correctly.  This is a step towards a pure-MPI version that would also use shared memory arrays wrapped by numpy arrays.  This has been tested with 50k targets over 100 deg2 from the 2% sprint, and for the first time the combination of MPI+multiprocessing worked well at scale.  We should still pursue a pure MPI version, but this provides a working reference state to relieve some of the urgency for the MPI refactor.

### Technical details for the record ###

When the spectra are originally read from disk, their flux, ivar, mask, and resolution data are put into `multiprocessing.RawArray()` shared memory arrays.  These are wrapped with `numpy.frombuffer()` to make normal numpy ndarray views of these buffers.  This enables the algorithm code to use them without any changes.

Now for the messy bit.  When those are passed to new multiprocessing processes, normally multiprocessing would see the numpy array and try to pickle it thus losing the shared memory benefit.  So I had to implement pack/unpack functions to remove the numpy wrappers, pass to the multiprocessing function as a plain shared memory buffer (RawArray), and then convert them back to the numpy-wrapped state for use.

Summarizing what I like:
  1. explicitly sharing memory rather than implicitly hoping that os.fork will get it right (when wrapped by Cray MPI, it doesn't...)
  2. algorithm code didn't have to change; parallelism is still contained in just 2 wrapper functions of the core algorithm code.
  3. it works (for now)

Summarizing what I didn't like:
  1. I had to change the fundamental data objects themselves (Spectra, Targets), though at least this was done in a way that didn't impact algorithm usage of them
  2. The pack/unpack for passing to multiprocessing is messy, but is at least isolated to the two `parallel_*` functions and not anywhere else.

I think the MPI version will use a modified version of Bad Thing (1) but may be able to avoid Bad Thing (2).  We should strive to maintain as much as Good Thing (2) as we can (not mucking up algorithm code with parallelism details).
