### PR TITLE
Further MPI improvements

### DIFF
--- a/bin/rrdesi
+++ b/bin/rrdesi
@@ -4,4 +4,4 @@
 Redrock for DESI
 """
 from redrock.external import desi
-desi.rrdesi_multiprocessing()
+desi.rrdesi()

--- a/bin/rrdesi_mpi
+++ b/bin/rrdesi_mpi
@@ -3,5 +3,23 @@
 """
 Redrock for DESI
 """
+import os
+
+# MPI environment availability
+have_mpi = None
+if ("NERSC_HOST" in os.environ) and ("SLURM_JOB_NAME" not in os.environ):
+    have_mpi = False
+else:
+    have_mpi = True
+    try:
+        import mpi4py.MPI as MPI
+    except ImportError:
+        have_mpi = False
+
 from redrock.external import desi
-desi.rrdesi_mpi()
+
+if have_mpi:
+	desi.rrdesi(comm=MPI.COMM_WORLD)
+else:
+	print("MPI not available, running serially")
+	desi.rrdesi()

--- a/py/redrock/__init__.py
+++ b/py/redrock/__init__.py
@@ -5,7 +5,8 @@ from __future__ import absolute_import, division, print_function
 
 __version__ = '0.4.2.dev1'
 
-from .dataobj import Target, MultiprocessingSharedSpectrum, SimpleSpectrum, MPISharedTargets, Template
+from .dataobj import (Target, MultiprocessingSharedSpectrum, 
+	SimpleSpectrum, MPISharedTargets, Template)
 from . import rebin
 from . import zscan
 from . import fitz

--- a/py/redrock/dataobj.py
+++ b/py/redrock/dataobj.py
@@ -4,11 +4,12 @@ import numpy as np
 import scipy.sparse
 from collections import OrderedDict
 
-from redrock.rebin import trapz_rebin
-from redrock import sharedmem
-from mpi4py import MPI
+from .rebin import trapz_rebin
+from . import sharedmem
+
 
 class Template(object):
+
     def __init__(self, template_type, redshifts, wave, flux, subtype=''):
         '''
         Create a spectral Template PCA object
@@ -62,6 +63,7 @@ class Template(object):
 
         
 class MultiprocessingSharedSpectrum(object):
+
     def __init__(self, wave, flux, ivar, R):
         """
         create a Spectrum object
@@ -121,7 +123,9 @@ class MultiprocessingSharedSpectrum(object):
         if hasattr(self, 'Rcsr'):
             del self.Rcsr
 
+
 class SimpleSpectrum(object):
+
     def __init__(self, wave, flux, ivar, R):
         self.nwave=wave.size
         self.wave=wave
@@ -132,10 +136,10 @@ class SimpleSpectrum(object):
         self.wavehash = hash((len(wave), wave[0], wave[1], wave[-2], wave[-1]))
 
 
+class MPISharedTargets(object):
 
-class MPISharedTargets(object) :
     def __init__(self, targets, comm):
-        
+
         
         if comm is None :
             raise ValueError('I NEED A MPI COMMUNICATOR')

--- a/py/redrock/dataobj.py
+++ b/py/redrock/dataobj.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 from .rebin import trapz_rebin
 from . import sharedmem
+from .sharedmem_mpi import MPIShared
 
 
 class Template(object):
@@ -139,167 +140,81 @@ class SimpleSpectrum(object):
 class MPISharedTargets(object):
 
     def __init__(self, targets, comm):
+        """
+        Place a list of targets into MPI shared memory.
 
-        
-        if comm is None :
-            raise ValueError('I NEED A MPI COMMUNICATOR')
-        
-        # Global communicator.        
+        Args:
+            targets (list): the list of targets.  This is ONLY meaningful
+                on the rank zero process.  Data on other processes is
+                ignored.
+            comm (mpi4py.MPI.Comm): the communicator to use (or None).
+        """
+
         self._comm = comm
-        self._rank = self._comm.rank
-        self._procs = self._comm.size
-        
-        #print('rank #%d : MPISharedTargets.__init__ starting'%self._rank)
+        self._dtype = np.dtype(np.float64)
 
-        if comm.rank==0 :
-            print('rank #%d : allocating a shared memory for targets '%self._rank)
-        
-        self._n = 0
-        self._dtype = np.dtype("float64")
-        self._target_dictionnary = None
-        
-        # for the moment, the whole memory allocation is going to the first rank
-        if self._rank == 0 :
-            dictionnary,ndata = self.fill_target_dictionnary(targets)
-            self._target_dictionnary = dictionnary
-            self._n = ndata
-            
-        #print('rank #%d : _n = %d'%(self._rank,self._n))
-        #print('rank #%d : allocating memory'%self._rank)
+        root = False
+        if self._comm is None:
+            root = True
+        elif self._comm.rank == 0:
+            root = True
 
-            
-        # We are actually using MPI, so we need to ensure that
-        # our specified numpy dtype has a corresponding MPI datatype.
-        status = 0
-        try:
-            # Technically this is an internal variable, but online
-            # forum posts from the developers indicate this is stable
-            # at least until a public interface is created.
-            self._mpitype = MPI._typedict[self._dtype.char]
-        except:
-            status = 1
-        self._checkabort(self._comm, status, "numpy to MPI type conversion")
-        
-        # Number of bytes in our buffer
-        dsize = self._mpitype.Get_size()
-        nbytes = self._n * dsize
-                    
-        # allocating the shared memory
-        # all ranks have to go through this even if they don't allocate anything (_n=nbytes=0 for rank>0)
-        # otherwise this does not work (don't ask me why)
-        status = 0
-        try:
-            self._win = MPI.Win.Allocate_shared(nbytes, dsize,comm=self._comm)
-        except:
-            status = 1
-        self._checkabort(self._comm, status, "shared memory allocation")
-        #print('rank #%d : MPISharedTargets.__init__ memory allocated'%self._rank)
-        
-        # Every process looks up the memory address of rank zero's piece,
-        # which is the start of the contiguous shared buffer.
-        # print('rank #%d : MPISharedTargets.__init__ get memory address'%self._rank)
-        status = 0
-        try:
-            self._buffer, dsize = self._win.Shared_query(0)
-        except:
-            status = 1
-        self._checkabort(self._comm, status, "shared memory query")
+        # We are going to pack the target data into one big memory buffer.
+        # First compute the displacements of the data for each target.
 
-        # Create a numpy array which acts as a "view" of the buffer.
-        self._dbuf = np.array(self._buffer, dtype="B", copy=False)
-        self._data = self._dbuf.view(self._dtype) # here is the data !!
-        # print('rank #%d : MPISharedTargets.__init__ have the data view'%self._rank)
-        
-        
-        if self._rank == 0 :
+        self._target_dictionary = None
+        self._bufsize = None
 
-            print('rank #%d : fill the memory with the data'%self._rank)
-            
-            # Get a write-lock on the shared memory
-            self._win.Lock(self._rank, MPI.LOCK_EXCLUSIVE)
+        if root:
+            self._target_dictionary, self._bufsize = \
+                self._fill_target_dictionary(targets)
+        
+        if self._comm is not None:
+            self._target_dictionary = self._comm.bcast(self._target_dictionary,
+                root=0)
+            self._bufsize = self._comm.bcast(self._bufsize, root=0)
 
-            # Copy data ...
-            for target in targets :
-                tdict=self._target_dictionnary[target.id]
-                for spectra_dict_list_label,spectra_list in zip(["spectra","coadd"],[target.spectra,target.coadd]) :
-                    spectra_dict_list=tdict[spectra_dict_list_label]
-                    for spectrum_dict , spectrum in zip(spectra_dict_list,spectra_list) :
-                        for label,an_array in zip(["wave","flux","ivar","rdata","roffsets","rshape"],
-                                                  [spectrum.wave,spectrum.flux,spectrum.ivar,spectrum.R.data,spectrum.R.offsets.astype(self._dtype),np.array(spectrum.R.shape).astype(self._dtype)]) :
-                            begin=spectrum_dict[label][0]
-                            end=spectrum_dict[label][1]                            
-                            self._data[begin:end] = an_array.ravel()
-                        first=False
-            # Release the write-lock
-            self._win.Unlock(self._rank)
+        # Allocate the shared buffer
+        self._shared = MPIShared((self._bufsize,), self._dtype, self._comm)
 
-            #print('rank #%d : MPISharedTargets.__init__ done filling the shared memory'%self._rank)
-            
-        # Explicit barrier here, to ensure that other processes do not try
-        # reading data before the writing processes have finished.
-        self._comm.barrier()
+        # Now set the shared data buffer, one target at a time
 
-        #print('rank #%d : MPISharedSpectrum.__init__ broadcasting target_dictionnary'%self._rank)
-        self._target_dictionnary = comm.bcast(self._target_dictionnary,root=0)
-        
-        #print('rank #%d : MPISharedSpectrum.__init__ unpacking targets'%self._rank)
-        self.targets = self.get_targets()
+        targetnum = 0
+        for id, tdict in self._target_dictionary.items():
+            for spectra_label in ["spectra", "coadd"]:
+                specnum = 0
+                for spectra_dict in tdict[spectra_label]:
+                    target_begin = spectra_dict["wave"][0]
+                    target_end = spectra_dict["rshape"][1]
+                    target_buffer = None
+                    if root:
+                        assert targets[targetnum].id == id
+                        target_buffer = np.empty((target_end - target_begin,),
+                            dtype=np.float64)
+                        spectrum = None
+                        if spectra_label == "spectra":
+                            spectrum = targets[targetnum].spectra[specnum]
+                        elif spectra_label == "coadd":
+                            spectrum = targets[targetnum].coadd[specnum]
+                        for label, an_array in zip(["wave", "flux", "ivar", 
+                            "rdata", "roffsets", "rshape"], [spectrum.wave,
+                            spectrum.flux, spectrum.ivar, spectrum.R.data, 
+                            spectrum.R.offsets.astype(self._dtype),
+                            np.array(spectrum.R.shape).astype(self._dtype)]):
+                            begin = spectra_dict[label][0] - target_begin
+                            end = spectra_dict[label][1] - target_begin
+                            target_buffer[begin:end] = an_array.ravel()
+                    self._shared.set(target_buffer, (target_begin,), 
+                        fromrank=0)
+                    specnum += 1
+            targetnum += 1
 
-        print('rank #%d : I have the %d targets'%(self._rank,len(self.targets)))
-        
-        
-        #print('rank #%d : MPISharedSpectrum.__init__ ending'%self._rank)
+        # Wrap the target data in a friendlier format.  This will likely
+        # duplicate some data from the resolution matrix.
 
-        
-    def _checkabort(self, comm, status, msg):
-        if status != 0 :
-            print("rank #{} : MPI ERROR : {}".format(comm.rank,msg))
-            sys.stdout.flush()
-            comm.Abort()  # unfortunately this removes all print messages, need to check this now that I added a flush ...
-        
-    
-    
-    def fill_target_dictionnary(self,targets) :
-        
-        n=0
-        dictionnary=OrderedDict() # keep targets as ordered in list
-        for target in targets :
-            dictionnary[target.id]={}
-            for spectra_label, spectra in zip(["spectra","coadd"],[target.spectra,target.coadd]) :
-                spectra_list=list()
-                for spectrum in spectra :
-                    spectrum_dic={}
-                    for label,asize in zip(["wave","flux","ivar","rdata","roffsets","rshape"],[spectrum.wave.size,spectrum.flux.size,spectrum.ivar.size,spectrum.R.data.size,spectrum.R.offsets.size,len(spectrum.R.shape)]) :
-                        spectrum_dic[label]=[n,n+asize] ; n+=asize
-                    spectra_list.append(spectrum_dic)
-                dictionnary[target.id][spectra_label]=spectra_list
-        return dictionnary,n
+        self.targets = self._get_targets()
 
-    def get_targets(self) :
-        #print("rank #%d : get_targets"%self._rank)
-        targets = list()
-        for targetid in self._target_dictionnary.keys() :
-            tdict=self._target_dictionnary[targetid]
-            spectra=list()
-            coadd=list()
-            for spectra_dict_list_label, spectra_ref in zip(["spectra","coadd"],[spectra,coadd]) :
-                spectra_dict_list=tdict[spectra_dict_list_label]
-                for spectrum_dict in spectra_dict_list :
-                    # we are not doing a copy here (except maybe for R ...)
-                    wave=self._data[spectrum_dict["wave"][0]:spectrum_dict["wave"][1]]
-                    flux=self._data[spectrum_dict["flux"][0]:spectrum_dict["flux"][1]]
-                    ivar=self._data[spectrum_dict["ivar"][0]:spectrum_dict["ivar"][1]]
-                    rdata=self._data[spectrum_dict["rdata"][0]:spectrum_dict["rdata"][1]]
-                    roffsets=self._data[spectrum_dict["roffsets"][0]:spectrum_dict["roffsets"][1]]
-                    rshape=tuple(self._data[spectrum_dict["rshape"][0]:spectrum_dict["rshape"][1]].astype(int))
-                    rdata=rdata.reshape((roffsets.size,rdata.shape[0]//roffsets.size))
-                    spectra_ref.append(SimpleSpectrum(wave,flux,ivar,scipy.sparse.dia_matrix((rdata, roffsets), shape=rshape)))            
-            targets.append(Target(targetid,spectra,coadd=coadd))
-        #print("rank #%d : done get_targets"%self._rank)
-        return targets
-    
-        
-    
+
     def __del__(self):
         self.close()
     
@@ -311,11 +226,56 @@ class MPISharedTargets(object):
         return False
 
     def close(self):
-        # The shared memory window is automatically freed
-        # when the class instance is garbage collected.
-        # This function is for any other clean up on destruction.
         return
-    
+
+
+    def _fill_target_dictionary(self, targets):
+        n = 0
+        dictionary = OrderedDict() # keep targets as ordered in list
+        for target in targets :
+            dictionary[target.id] = {}
+            for spectra_label, spectra in zip(["spectra", "coadd"], 
+                [target.spectra, target.coadd]):
+                spectra_list = list()
+                for spectrum in spectra :
+                    spectrum_dict = {}
+                    for label, asize in zip(["wave","flux","ivar","rdata",
+                        "roffsets","rshape"], [spectrum.wave.size, 
+                        spectrum.flux.size, spectrum.ivar.size, 
+                        spectrum.R.data.size, spectrum.R.offsets.size,
+                        len(spectrum.R.shape)]):
+                        spectrum_dict[label] = [n, n + asize]
+                        n += asize
+                    spectra_list.append(spectrum_dict)
+                dictionary[target.id][spectra_label] = spectra_list
+        return dictionary, n
+
+
+    def _get_targets(self):
+        targets = list()
+        for id, tdict in self._target_dictionary.items():
+            spectra = list()
+            coadd = list()
+            for spectra_label, spectra_ref in zip(["spectra", "coadd"],
+                [spectra, coadd]):
+                spectra_dict_list = tdict[spectra_label]
+                for spectrum_dict in spectra_dict_list :
+                    # we are not doing a copy here (except maybe for R ...)
+                    wave = self._shared[spectrum_dict["wave"][0]:spectrum_dict["wave"][1]]
+                    flux = self._shared[spectrum_dict["flux"][0]:spectrum_dict["flux"][1]]
+                    ivar = self._shared[spectrum_dict["ivar"][0]:spectrum_dict["ivar"][1]]
+                    rdata = self._shared[spectrum_dict["rdata"][0]:spectrum_dict["rdata"][1]]
+                    roffsets = self._shared[spectrum_dict["roffsets"][0]:spectrum_dict["roffsets"][1]]
+                    rshape = tuple(self._shared[spectrum_dict["rshape"][0]:spectrum_dict["rshape"][1]].astype(int))
+                    rdata = rdata.reshape((roffsets.size,rdata.shape[0]//roffsets.size))
+                    spectra_ref.append( SimpleSpectrum(wave, flux, ivar, 
+                        scipy.sparse.dia_matrix((rdata, roffsets), 
+                        shape=rshape)) )            
+            targets.append(Target(id, spectra, coadd=coadd))
+
+        return targets
+
+
 class Target(object):
     def __init__(self, targetid, spectra, coadd=None):
         """

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -16,6 +16,7 @@ from desispec.resolution import Resolution
 from .. import Target
 from .. import MultiprocessingSharedSpectrum, SimpleSpectrum,  MPISharedTargets
 
+
 def write_zbest(outfile, zbest):
     '''
     Write zbest Table to outfile
@@ -32,6 +33,7 @@ def write_zbest(outfile, zbest):
 
     zbest.meta['EXTNAME'] = 'ZBEST'
     zbest.write(outfile, overwrite=True)
+
 
 def read_spectra(spectrafiles, targetids=None, spectrum_class=None):
     '''
@@ -110,6 +112,7 @@ def read_spectra(spectrafiles, targetids=None, spectrum_class=None):
     meta['BRICKNAME'] = bricknames
 
     return targets, meta
+
 
 def read_bricks(brickfiles, trueflux=False, targetids=None, spectrum_class=None):
     '''
@@ -192,6 +195,7 @@ def read_bricks(brickfiles, trueflux=False, targetids=None, spectrum_class=None)
     meta['BRICKNAME'] = bricknames
 
     return targets, meta
+
 
 def rrdesi_multiprocessing(options=None):
     import redrock

--- a/py/redrock/fitz.py
+++ b/py/redrock/fitz.py
@@ -2,8 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import numpy as np
-import redrock
-from redrock.zwarning import ZWarningMask as ZW
+
+from . import sharedmem
+from . import zscan
+from .zwarning import ZWarningMask as ZW
+
 
 def find_minima(x):
     '''
@@ -19,6 +22,7 @@ def find_minima(x):
     jj = np.argsort(x[ii])
 
     return ii[jj]
+
 
 def minfit(x,y):
     '''
@@ -56,9 +60,10 @@ def minfit(x,y):
 
     return (x0, xerr, y0, zwarn)
 
+
 def _wrap_fitz(target_indices, qout, zchi2, redshifts, targets, template, nminima):
     #- unpack shared memory buffers into numpy arrays
-    zchi2 = redrock.sharedmem.toarray(zchi2)
+    zchi2 = sharedmem.toarray(zchi2)
     try:
         for j in target_indices:
             targets[j].sharedmem_unpack()
@@ -71,6 +76,7 @@ def _wrap_fitz(target_indices, qout, zchi2, redshifts, targets, template, nminim
         qout.put( (target_indices[0], err, message) )
 
     qout.close()
+
 
 def parallel_fitz_targets(zchi2, redshifts, targets, template, nminima=3, ncpu=None):
     '''
@@ -89,7 +95,7 @@ def parallel_fitz_targets(zchi2, redshifts, targets, template, nminima=3, ncpu=N
     ncpu = min(len(targets), ncpu)
 
     #- Pack arrays into shared memory for sending to processes
-    zchi2 = redrock.sharedmem.fromarray(zchi2)
+    zchi2 = sharedmem.fromarray(zchi2)
     for t in targets:
         t.sharedmem_pack()
 
@@ -185,7 +191,6 @@ def mpi_fitz_targets(zchi2, redshifts, targets, template, nminima=3, comm=None):
     return results
 
 
-
 def fitz(zchi2, redshifts, spectra, template, nminima=3):
     '''Refines redshift measurement around up to nminima minima
 
@@ -210,13 +215,13 @@ def fitz(zchi2, redshifts, spectra, template, nminima=3):
         ilo = max(0, imin-1)
         ihi = min(imin+1, len(zchi2)-1)
         zz = np.linspace(redshifts[ilo], redshifts[ihi], 15)
-        zzchi2, zzcoeff, zzpenalty = redrock.zscan.calc_zchi2(zz, spectra, template)
+        zzchi2, zzcoeff, zzpenalty = zscan.calc_zchi2(zz, spectra, template)
 
         #- fit parabola to 3 points around minimum
         i = min(max(np.argmin(zzchi2),1), len(zz)-2)
         zmin, sigma, chi2min, zwarn = minfit(zz[i-1:i+2], zzchi2[i-1:i+2])
         try:
-            coeff = redrock.zscan.calc_zchi2([zmin,], spectra, template)[1][0]
+            coeff = zscan.calc_zchi2([zmin,], spectra, template)[1][0]
         except ValueError as err:
             if zmin<redshifts[0] or redshifts[-1]<zmin:
                 #- beyond redshift range can be invalid for template

--- a/py/redrock/io.py
+++ b/py/redrock/io.py
@@ -14,6 +14,7 @@ from . import Template
 if sys.version_info.major > 2:
     basestring = str
 
+
 #- From https://github.com/desihub/desispec io.util.native_endian
 def native_endian(data):
     """Convert numpy array data to native endianness if needed.
@@ -29,6 +30,7 @@ def native_endian(data):
         return data
     else:
         return data.byteswap().newbyteorder()
+
 
 def read_template(filename):
     '''
@@ -72,6 +74,7 @@ def read_template(filename):
 
     return Template(rrtype, redshifts, wave, flux, subtype=subtype)
 
+
 def find_templates(template_dir=None):
     '''
     Return list of redrock-*.fits template files
@@ -95,6 +98,7 @@ def find_templates(template_dir=None):
 
     return glob(os.path.join(template_dir, 'rrtemplate-*.fits'))
 
+
 def read_templates(template_list=None, template_dir=None):
     '''
     Return a list of templates from the files in template_list
@@ -116,6 +120,7 @@ def read_templates(template_list=None, template_dir=None):
         raise IOError('No templates found')
     
     return templates
+
 
 def write_zscan(filename, zscan, zfit, clobber=False):
     '''
@@ -176,7 +181,8 @@ def write_zscan(filename, zscan, zfit, clobber=False):
         #- TODO: fx['zfit/{}/model']
 
     fx.close()
-    
+
+
 def read_zscan(filename):
     '''Return redrock.zfind results stored in hdf5 file as written
     by write_zscan
@@ -229,9 +235,11 @@ def read_zscan(filename):
 
     return zscan, zfit
 
+
 def _encode_column(c):
     '''Returns a bytes column encoded into a string column'''
     return c.astype((str, c.dtype.itemsize))
+
 
 #- Adapted from http://stackoverflow.com/a/21659588; unix only
 def getch():

--- a/py/redrock/plotspec.py
+++ b/py/redrock/plotspec.py
@@ -1,7 +1,10 @@
+
+import time
 import numpy as np
 
-import redrock.io
-import time
+from . import io
+from . import zwarning
+
 
 class PlotSpec(object):
     def __init__(self, targets, templates, zscan, zfit, truth=None):
@@ -157,7 +160,7 @@ class PlotSpec(object):
         #- ZWARN labels
         if zz['zwarn'] != 0:
             label = list()
-            for name, mask in redrock.zwarning.ZWarningMask.flags():
+            for name, mask in zwarning.ZWarningMask.flags():
                 if (zz['zwarn'] & mask) != 0:
                     label.append(name)
             label = '\n'.join(label)

--- a/py/redrock/rebin.py
+++ b/py/redrock/rebin.py
@@ -22,6 +22,7 @@ def centers2edges(centers):
 
     return edges
 
+
 #- numba JIT compiler doesn't seem to like keyword args, so wrap it
 def trapz_rebin(x, y, xnew=None, edges=None):
     if edges is None:
@@ -33,6 +34,7 @@ def trapz_rebin(x, y, xnew=None, edges=None):
         raise ValueError('edges must be within input x range')
 
     return _trapz_rebin(x, y, edges)
+
 
 @numba.jit
 def _trapz_rebin(x, y, edges):

--- a/py/redrock/sharedmem.py
+++ b/py/redrock/sharedmem.py
@@ -18,6 +18,7 @@ read-only inputs.
 import numpy as np
 import multiprocessing as mp
 
+
 def fromarray(x):
     '''
     Copies array `x` into a shared memory buffer
@@ -32,6 +33,7 @@ def fromarray(x):
     a = np.frombuffer(rawbuf, dtype=x.dtype).reshape(x.shape)
     a[:] = x
     return (rawbuf, x.dtype, x.shape)
+
 
 def toarray(raw):
     '''

--- a/py/redrock/sharedmem_mpi.py
+++ b/py/redrock/sharedmem_mpi.py
@@ -7,24 +7,10 @@ https://github.com/tskisner/mpi_shmem
 revision:  c10498f227db809365c362e13d18a77a429a09ae
 '''
 
-import os
-
-# MPI environment availability
-
-have_mpi = None
-"""Whether we can use MPI.  Set globally on first import."""
-
-if ("NERSC_HOST" in os.environ) and ("SLURM_JOB_NAME" not in os.environ):
-    have_mpi = False
-else:
-    have_mpi = True
-    try:
-        import mpi4py.MPI as MPI
-    except ImportError:
-        have_mpi = False
-
 import sys
 import numpy as np
+
+import mpi4py.MPI as MPI
 
 
 class MPIShared(object):

--- a/py/redrock/sharedmem_mpi.py
+++ b/py/redrock/sharedmem_mpi.py
@@ -1,0 +1,417 @@
+'''
+Utilities for working with MPI shared memory arrays.  Copied
+from:
+
+https://github.com/tskisner/mpi_shmem
+
+revision:  c10498f227db809365c362e13d18a77a429a09ae
+'''
+
+import os
+
+# MPI environment availability
+
+have_mpi = None
+"""Whether we can use MPI.  Set globally on first import."""
+
+if ("NERSC_HOST" in os.environ) and ("SLURM_JOB_NAME" not in os.environ):
+    have_mpi = False
+else:
+    have_mpi = True
+    try:
+        import mpi4py.MPI as MPI
+    except ImportError:
+        have_mpi = False
+
+import sys
+import numpy as np
+
+
+class MPIShared(object):
+    """
+    Create a shared memory buffer that is replicated across nodes.
+
+    For the given array dimensions and datatype, the original communicator
+    is split into groups of processes that can share memory (i.e. that are
+    on the same node).
+
+    The values of the memory buffer can be set by one process at a time.
+    When the set() method is called the data passed by the specified
+    process is replicated to all nodes and then copied into the desired
+    place in the shared memory buffer on each node.  This way the shared
+    buffer on each node is identical.
+
+    All processes across all nodes may do read-only access to their node-
+    local copy of the buffer, simply by using the standard array indexing
+    notation ("[]") on the object itself.
+
+    Args:
+        shape (tuple): the dimensions of the array.
+        dtype (np.dtype): the data type of the array.
+        comm (MPI.Comm): the full communicator to use.  This may span
+            multiple nodes, and each node will have a copy.
+    """
+    def __init__(self, shape, dtype, comm):
+        self._shape = shape
+        self._dtype = dtype
+
+        # Global communicator.
+        
+        self._comm = comm
+        self._rank = 0
+        self._procs = 1
+        if self._comm is not None:
+            self._rank = self._comm.rank
+            self._procs = self._comm.size
+        
+        # Compute the flat-packed buffer size.
+
+        self._n = 1
+        for d in self._shape:
+            self._n *= d
+
+        # Split our communicator into groups on the same node.  Also
+        # create an inter-node communicator between corresponding
+        # processes on all nodes (for use in "setting" slices of the
+        # buffer.
+        
+        self._nodecomm = None
+        self._rankcomm = None
+        self._noderank = 0
+        self._nodeprocs = 1
+        self._nodes = 1
+        self._mynode = 0
+        if self._comm is not None:
+            self._nodecomm = self._comm.Split_type(MPI.COMM_TYPE_SHARED, 0)
+            self._noderank = self._nodecomm.rank
+            self._nodeprocs = self._nodecomm.size
+            self._nodes = self._procs // self._nodeprocs
+            if self._nodes * self._nodeprocs < self._procs:
+                self._nodes += 1
+            self._mynode = self._rank // self._nodeprocs
+            self._rankcomm = self._comm.Split(self._noderank, self._mynode)
+
+        # Consider a corner case of the previous calculation.  Imagine that
+        # the number of processes is not evenly divisible by the number of
+        # processes per node.  In that case, when we later use the set()
+        # method, the rank-wise communicator may not have a member on the
+        # final node.  Here we compute the "highest" rank within a node which
+        # is present on all nodes.  That sets the possible allowed processes
+        # which may call the set() method.
+
+        dist = self._disthelper(self._procs, self._nodes)
+        self._maxsetrank = dist[-1][1] - 1
+
+        # Divide up the total memory size among the processes on each
+        # node.  For reasonable NUMA settings, this should spread the
+        # allocated memory to locations across the node.
+
+        # FIXME: the above statement works fine for allocating the window,
+        # and it is also great in C/C++ where the pointer to the start of 
+        # the buffer is all you need.  In mpi4py, querying the rank-0 buffer
+        # returns a buffer-interface-compatible object, not just a pointer.
+        # And this "buffer object" has the size of just the rank-0 allocated
+        # data.  SO, for now, disable this and have rank 0 allocate the whole
+        # thing.  We should change this back once we figure out how to
+        # take the raw pointer from rank zero and present it to numpy as the
+        # the full buffer.
+
+        # dist = self._disthelper(self._n, self._nodeprocs)
+        # self._localoffset, self._nlocal = dist[self._noderank]
+        if self._noderank == 0:
+            self._localoffset = 0
+            self._nlocal = self._n
+        else:
+            self._localoffset = 0
+            self._nlocal = 0
+
+        # Allocate the shared memory buffer and wrap it in a 
+        # numpy array.  If the communicator is None, just make
+        # a normal numpy array.
+
+        self._mpitype = None
+        self._win = None
+        self._buffer = None
+        self._dbuf = None
+        self._flat = None
+        self._data = None
+
+        if self._comm is not None:
+            # We are actually using MPI, so we need to ensure that
+            # our specified numpy dtype has a corresponding MPI datatype.
+            status = 0
+            try:
+                # Technically this is an internal variable, but online
+                # forum posts from the developers indicate this is stable
+                # at least until a public interface is created.
+                self._mpitype = MPI._typedict[self._dtype.char]
+            except:
+                status = 1
+            self._checkabort(self._comm, status, 
+                "numpy to MPI type conversion")
+
+            # Number of bytes in our buffer
+            dsize = self._mpitype.Get_size()
+            nbytes = self._nlocal * dsize
+
+            # Every process allocates a piece of the buffer.  The per-
+            # process pieces are guaranteed to be contiguous.
+            status = 0
+            try:
+                self._win = MPI.Win.Allocate_shared(nbytes, dsize, 
+                    comm=self._nodecomm)
+            except:
+                status = 1
+            self._checkabort(self._nodecomm, status, 
+                "shared memory allocation")
+
+            # Every process looks up the memory address of rank zero's piece,
+            # which is the start of the contiguous shared buffer.
+            status = 0
+            try:
+                self._buffer, dsize = self._win.Shared_query(0)
+            except:
+                status = 1
+            self._checkabort(self._nodecomm, status, "shared memory query")
+
+            # Create a numpy array which acts as a "view" of the buffer.
+            self._dbuf = np.array(self._buffer, dtype="B", copy=False)
+            self._flat = self._dbuf.view(self._dtype)
+            self._data = self._flat.reshape(self._shape)
+
+            # Initialize to zero.  Any of the processes could do this to the
+            # whole buffer, but it is safe and easy for each process to just
+            # initialize its local piece.
+
+            # FIXME: change this back once every process is allocating a 
+            # piece of the buffer.            
+            # self._flat[self._localoffset:self._localoffset + self._nlocal] = 0
+            if self._noderank == 0:
+                self._flat[:] = 0
+
+        else:
+            self._data = np.zeros(_n, dtype=_dtype).reshape(_shape)
+
+
+    def __del__(self):
+        self.close()
+        
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, type, value, tb):
+        self.close()
+        return False
+
+
+    def close(self):
+        # The shared memory window is automatically freed
+        # when the class instance is garbage collected.
+        # This function is for any other clean up on destruction.
+        return
+
+
+    @property
+    def shape(self):
+        """
+        The tuple of dimensions of the shared array.
+        """
+        return self._shape
+
+
+    @property
+    def dtype(self):
+        """
+        The numpy datatype of the shared array.
+        """
+        return self._dtype
+
+
+    @property
+    def comm(self):
+        """
+        The full communicator.
+        """
+        return self._comm
+
+
+    @property
+    def nodecomm(self):
+        """
+        The node-local communicator.
+        """
+        return self._nodecomm
+
+
+    def _disthelper(self, n, groups):
+        dist = []
+        for i in range(groups):
+            myn = n // groups
+            first = 0
+            leftover = n % groups
+            if i < leftover:
+                myn += 1
+                first = i * myn
+            else:
+                first = ((myn + 1) * leftover) + (myn * (i - leftover))
+            dist.append( (first, myn) )
+        return dist
+
+
+    def _checkabort(self, comm, status, msg):
+        failed = comm.allreduce(status, op=MPI.SUM)
+        if failed > 0:
+            if comm.rank == 0:
+                print("MPIShared: one or more processes failed: {}".format(
+                    msg))
+                sys.stdout.flush()
+                comm.Abort()
+        return
+
+
+    def set(self, data, offset, fromrank=0):
+        """
+        Set the values of a slice of the shared array.
+
+        This call is collective across the full communicator, but only the
+        data input from process "fromrank" is meaningful.  The offset 
+        specifies the starting element along each dimension when copying
+        the data into the shared array.  Regardless of which node the 
+        "fromrank" process is on, the data will be replicated to the
+        shared memory buffer on all nodes.
+
+        Args:
+            data (array): a numpy array with the same number of dimensions
+                as the full array.
+            offset (tuple): the starting offset along each dimension, which
+                determines where the input data should be inserted into the
+                shared array.
+            fromrank (int): the process rank of the full communicator which
+                is passing in the data.
+
+        Returns:
+            Nothing
+        """
+        # Explicit barrier here, to ensure that we don't try to update
+        # data while other processes are reading.
+        if self._comm is not None:
+            self._comm.barrier()
+
+        # First check that the dimensions of the data and the offset tuple
+        # match the shape of the data.
+
+        if self._rank == fromrank:
+            if len(data.shape) != len(self._shape):
+                msg = "data has incompatible number of dimensions"
+                if self._comm is not None:
+                    print(msg)
+                    sys.stdout.flush()
+                    #self._comm.Abort()
+                else:
+                    raise RuntimeError(msg)
+            if len(offset) != len(self._shape):
+                msg = "offset tuple has incompatible number of dimensions"
+                if self._comm is not None:
+                    print(msg)
+                    sys.stdout.flush()
+                    #self._comm.Abort()
+                else:
+                    raise RuntimeError(msg)
+            if data.dtype != self._dtype:
+                msg = "input data has different type than shared array"
+                if self._comm is not None:
+                    print(msg)
+                    sys.stdout.flush()
+                    #self._comm.Abort()
+                else:
+                    raise RuntimeError(msg)
+
+        # The input data is coming from exactly one process on one node.
+        # First, we broadcast the data from this process to the same node-rank
+        # process on each of the nodes.
+
+        if self._comm is not None:
+            target_noderank = self._comm.bcast(self._noderank, root=fromrank)
+            fromnode = self._comm.bcast(self._mynode, root=fromrank)
+
+            # Verify that the node rank with the data actually has a member on
+            # every node (see notes in the constructor).
+            if target_noderank > self._maxsetrank:
+                if self._rank == 0:
+                    print("set() called with data from a node rank which does"
+                        " not exist on all nodes")
+                    self._comm.Abort()
+
+            if self._noderank == target_noderank:
+                # We are the lucky process on this node that gets to write
+                # the data into shared memory!
+
+                # Broadcast the offsets of the input slice
+                copyoffset = None
+                if self._mynode == fromnode:
+                    copyoffset = offset
+                copyoffset = self._rankcomm.bcast(copyoffset, root=fromnode)
+
+                # Pre-allocate buffer, so that we can use the low-level
+                # (and faster) Bcast method.
+                datashape = None
+                if self._mynode == fromnode:
+                    datashape = data.shape
+                datashape = self._rankcomm.bcast(datashape, root=fromnode)
+                
+                nodedata = None
+                if self._mynode == fromnode:
+                    nodedata = np.copy(data)
+                else:
+                    nodedata = np.zeros(datashape, dtype=self._dtype)
+
+                # Broadcast the data buffer
+                self._rankcomm.Bcast(nodedata, root=fromnode)
+
+                # Now one process on every node has a copy of the data, and
+                # can copy it into the shared memory buffer.
+
+                dslice = []
+                ndims = len(nodedata.shape)
+                for d in range(ndims):
+                    dslice.append( slice(copyoffset[d], 
+                        copyoffset[d]+nodedata.shape[d], 1) )
+                slc = tuple(dslice)
+
+                # Get a write-lock on the shared memory
+                self._win.Lock(self._noderank, MPI.LOCK_EXCLUSIVE)
+
+                # Copy data slice
+                self._data[slc] = nodedata
+
+                # Release the write-lock
+                self._win.Unlock(self._noderank)
+
+        else:
+            # We are just copying to a numpy array...
+            dslice = []
+            ndims = len(data.shape)
+            for d in range(ndims):
+                dslice.append( slice(offset[d], offset[d]+data.shape[d], 1) )
+            slc = tuple(dslice)
+
+            self._data[slc] = data
+
+        # Explicit barrier here, to ensure that other processes do not try
+        # reading data before the writing processes have finished.
+        if self._comm is not None:
+            self._comm.barrier()
+
+        return
+
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+
+    def __setitem__(self, key, value):
+        raise NotImplementedError("Setting individual array elements not"
+            " supported.  Use the set() method instead.")
+

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -5,15 +5,16 @@ import os, sys
 import time
 import numpy as np
 
-import redrock.zscan
-import redrock.fitz
-from redrock.zwarning import ZWarningMask as ZW
+from . import zscan
+from . import fitz
+from .zwarning import ZWarningMask as ZW
 
 import multiprocessing as mp
 
+
 def _wrap_calc_zchi2(args):
     try:
-        return redrock.zscan.calc_zchi2_targets(*args)
+        return zscan.calc_zchi2_targets(*args)
     except Exception as oops:
         print('-'*60)
         print('ERROR: calc_zchi2_targets raised exception; original traceback:')
@@ -22,6 +23,7 @@ def _wrap_calc_zchi2(args):
         print('...propagating exception upwards')
         print('-'*60)
         raise oops
+
 
 def zfind(targets, templates, ncpu=None, comm=None, nminima=3):
     '''
@@ -79,11 +81,11 @@ def zfind(targets, templates, ncpu=None, comm=None, nminima=3):
         
         t0 = time.time()
         if ncpu > 1:
-            zchi2, zcoeff, penalty = redrock.zscan.parallel_calc_zchi2_targets(t.redshifts, targets, t, ncpu=ncpu)
+            zchi2, zcoeff, penalty = zscan.parallel_calc_zchi2_targets(t.redshifts, targets, t, ncpu=ncpu)
         elif comm is not None :
-            zchi2, zcoeff, penalty = redrock.zscan.mpi_calc_zchi2_targets(t.redshifts, targets, t, comm=comm)
+            zchi2, zcoeff, penalty = zscan.mpi_calc_zchi2_targets(t.redshifts, targets, t, comm=comm)
         else:
-            zchi2, zcoeff, penalty = redrock.zscan.calc_zchi2_targets(t.redshifts, targets, t)
+            zchi2, zcoeff, penalty = zscan.calc_zchi2_targets(t.redshifts, targets, t)
         dt = time.time() - t0
 
         if comm is None or comm.rank==0 :
@@ -91,11 +93,11 @@ def zfind(targets, templates, ncpu=None, comm=None, nminima=3):
 
         t0 = time.time()
         if comm is None : # multiprocessing version
-            zfits = redrock.fitz.parallel_fitz_targets(
+            zfits = fitz.parallel_fitz_targets(
                 zchi2+penalty, t.redshifts, targets, t,
                 ncpu=ncpu, nminima=nminima)
         else : # mpi version
-            zfits = redrock.fitz.mpi_fitz_targets(
+            zfits = fitz.mpi_fitz_targets(
                 zchi2+penalty, t.redshifts, targets, t,
                 comm=comm, nminima=nminima)
         dt = time.time() - t0

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -5,7 +5,7 @@ import os, sys
 import time
 import numpy as np
 
-from . import zscan
+from . import zscan as rrzscan
 from . import fitz
 from .zwarning import ZWarningMask as ZW
 
@@ -14,7 +14,7 @@ import multiprocessing as mp
 
 def _wrap_calc_zchi2(args):
     try:
-        return zscan.calc_zchi2_targets(*args)
+        return rrzscan.calc_zchi2_targets(*args)
     except Exception as oops:
         print('-'*60)
         print('ERROR: calc_zchi2_targets raised exception; original traceback:')
@@ -67,7 +67,7 @@ def zfind(targets, templates, ncpu=None, comm=None, nminima=3):
 
     if comm is not None :
         if comm.rank == 0 :
-            print("INFO: using MPI")
+            print("INFO: using MPI with {} processes".format(comm.size))
     elif ncpu > 1:
         print("INFO: using multiprocessing with {} cores".format(ncpu))
     else:
@@ -75,21 +75,22 @@ def zfind(targets, templates, ncpu=None, comm=None, nminima=3):
         
     for t in templates:
 
-        if comm is not None and (comm.rank == 0) :
-            print('rank #{} : starting zchi2 scan for {}'.format(comm.rank,t.fulltype))
-            sys.stdout.flush() #  this helps seeing something
+        # if comm is not None and (comm.rank == 0) :
+        #     print('INFO: starting zchi2 scan for {}'.format(comm.rank,
+        #         t.fulltype))
+        #     sys.stdout.flush() #  this helps seeing something
         
         t0 = time.time()
         if ncpu > 1:
-            zchi2, zcoeff, penalty = zscan.parallel_calc_zchi2_targets(t.redshifts, targets, t, ncpu=ncpu)
-        elif comm is not None :
-            zchi2, zcoeff, penalty = zscan.mpi_calc_zchi2_targets(t.redshifts, targets, t, comm=comm)
+            zchi2, zcoeff, penalty = rrzscan.parallel_calc_zchi2_targets(t.redshifts, targets, t, ncpu=ncpu)
+        elif comm is not None:
+            zchi2, zcoeff, penalty = rrzscan.mpi_calc_zchi2_targets(t.redshifts, targets, t, comm=comm)
         else:
-            zchi2, zcoeff, penalty = zscan.calc_zchi2_targets(t.redshifts, targets, t)
+            zchi2, zcoeff, penalty = rrzscan.calc_zchi2_targets(t.redshifts, targets, t)
         dt = time.time() - t0
 
-        if comm is None or comm.rank==0 :
-            print('DEBUG: PID {} {} zscan in {:.1f} seconds'.format(pid, t.fulltype, dt))
+        # if comm is None or comm.rank==0 :
+        #     print('DEBUG: PID {} {} zscan in {:.1f} seconds'.format(pid, t.fulltype, dt))
 
         t0 = time.time()
         if comm is None : # multiprocessing version
@@ -102,11 +103,10 @@ def zfind(targets, templates, ncpu=None, comm=None, nminima=3):
                 comm=comm, nminima=nminima)
         dt = time.time() - t0
 
-        if comm is None or comm.rank==0 :
-            print('DEBUG: PID {} {} fitz in {:.1f} seconds'.format(pid, t.fulltype, dt))
-        
-            
-        if comm is None or comm.rank==0 :
+        # if comm is None or comm.rank==0 :
+        #     print('DEBUG: PID {} {} fitz in {:.1f} seconds'.format(pid, t.fulltype, dt))
+  
+        if comm is None or comm.rank == 0 :
             
             for i,zfit in enumerate(zfits) :
                 zscan[targets[i].id][t.fulltype]['zfit'] = zfit
@@ -119,7 +119,7 @@ def zfind(targets, templates, ncpu=None, comm=None, nminima=3):
 
     sys.stdout.flush()
     
-    if comm is None or comm.rank==0 :
+    if comm is None or comm.rank == 0 :
         #- Convert individual zfit results into a zall array
         t0 = time.time()
         ### print('DEBUG: PID {} Making zall'.format(pid))
@@ -170,10 +170,10 @@ def zfind(targets, templates, ncpu=None, comm=None, nminima=3):
 
         zfit = astropy.table.vstack(zfit)
         dt = time.time() - t0
-        print('DEBUG: PID {} zall in {:.1f} seconds'.format(pid, dt))
+        #print('DEBUG: PID {} zall in {:.1f} seconds'.format(pid, dt))
     else :
-       zscan=None
-       zfit=None
+       zscan = None
+       zfit = None
     
     # no need to broadcast at the end of this routine
     # because only rank 0 will write the results


### PR DESCRIPTION
This does some cleanup of the MPI code and unifies the rrdesi() function so that it works for both MPI and multiprocessing.  This also uses the MPIShared class unmodified from the upstream source.  As an added benefit, this means that redrock using MPI can scale to more than one node for a single spectral group / brick.

I did not want to merge this to the existing mpi branch without someone taking a look.  @julienguy, let me know if this looks ok.  I tested it on a couple small spectra files to confirm that the multiprocessing and MPI cases agree and that they also give the same results as the current mpi branch.