### PR TITLE
Read spectra files directly to MPI shared memory

### DIFF
--- a/py/redrock/dataobj.py
+++ b/py/redrock/dataobj.py
@@ -425,10 +425,10 @@ class Target(object):
 
         if coadd is None:
             #- Make a basic coadd
-            compute_coadd(spectra, 
+            self.coadd = compute_coadd(spectra, 
                 spectrum_class=MultiprocessingSharedSpectrum)
         else :
-            self.coadd=coadd
+            self.coadd = coadd
 
 
     def sharedmem_pack(self):

--- a/py/redrock/dataobj.py
+++ b/py/redrock/dataobj.py
@@ -137,47 +137,86 @@ class SimpleSpectrum(object):
         self.wavehash = hash((len(wave), wave[0], wave[1], wave[-2], wave[-1]))
 
 
+def target_offsets(targets):
+    """
+    Construct a dictionary of buffer offsets.
+
+    This examines the sizes of the data for a list of existing targets and
+    creates a dictionary of offsets to use when packing these into a contiguous
+    memory buffer.  Offsets are computed for the wave, flux, ivar, rdata, 
+    roffsets and rshape data members.
+
+    The dictionary structure is
+    { target_id_1 : { "spectra" : [ {"wave" : [b,e] , "flux" : [b,e] ,  ....}
+    , ... ]} , "coadd" : [ ... ]},  target_id_2 : ... }, i.e. a dictionary of
+    targets identified by their id.
+    
+    Each target has two list of spectra labeled "spectra" and "coadd".  Each
+    spectrum in the two lists of spectra is a dictionary containing, for the
+    keys "wave", "flux", "ivar", "rdata", "roffsets" and "rshape", the begin
+    and end index of the array in the shared memory buffer.
+    
+    Args:
+        targets (list): the list of targets.
+
+    Returns:
+        - dictionary
+        - number of double precision elements in the memory buffer.
+    """
+    n = 0
+    dictionary = OrderedDict() # keep targets as ordered in list
+    for target in targets:
+        dictionary[target.id] = {}
+        for spectra_label, spectra in zip(["spectra", "coadd"], 
+            [target.spectra, target.coadd]):
+            spectra_list = list()
+            for spectrum in spectra :
+                spectrum_dict = {}
+                for label, asize in zip(["wave","flux","ivar","rdata",
+                    "roffsets","rshape"], [spectrum.wave.size, 
+                    spectrum.flux.size, spectrum.ivar.size, 
+                    spectrum.R.data.size, spectrum.R.offsets.size,
+                    len(spectrum.R.shape)]):
+                    spectrum_dict[label] = [n, n + asize]
+                    n += asize
+                spectra_list.append(spectrum_dict)
+            dictionary[target.id][spectra_label] = spectra_list
+    return dictionary, n
+
+
 class MPISharedTargets(object):
 
-    def __init__(self, targets, comm):
+    def __init__(self, size, offsets, comm):
         """
-        Place a list of targets into MPI shared memory.
-        This goes as follows.
-        1) The root process reads the targets, fills a dictionary containing
-        for each spectrum of each target, the indices of
-        the wave, flux, ivar, rdata, roffsets and rshape arrays in the shared
-        memory buffer ( see self._fill_target_dictionary for more details
-        on the format of this dictionary ).
-        2) The dictionary is broadcasted to all processes.
-        3) The root process allocates and fill the memory buffer with data.
-        4) All processes recreate the target list, using references to portions of 
-           the memory buffer for all wave, flux, ivar, rdata arrays.
+        Collection of targets in MPI shared memory.
+
+        This class wraps a buffer of MPI shared memory that is constructed
+        for a specific set of targets (with specific sizes and data
+        dimensions).  After construction, the target data is populated
+        either directly or by calling the insert method.
         
         Args:
-            targets (list): the list of targets.  This is ONLY meaningful
-                on the rank zero process.  Data on other processes is
-                ignored.
+            size (int): the number of double precision elements in the
+                memory buffer.
+            offsets (dict): the dictionary of buffer offsets for each target
+                and its different data vectors.  See target_offsets() for
+                more details.
             comm (mpi4py.MPI.Comm): the communicator to use (or None).
         """
-
         self._comm = comm
         self._dtype = np.dtype(np.float64)
 
-        root = False
+        self._root = False
         if self._comm is None:
-            root = True
+            self._root = True
         elif self._comm.rank == 0:
-            root = True
+            self._root = True
 
         # We are going to pack the target data into one big memory buffer.
         # First compute the displacements of the data for each target.
 
-        self._target_dictionary = None
-        self._bufsize = None
-
-        if root:
-            self._target_dictionary, self._bufsize = \
-                self._fill_target_dictionary(targets)
+        self._target_dictionary = offsets
+        self._bufsize = size
         
         if self._comm is not None:
             self._target_dictionary = self._comm.bcast(self._target_dictionary,
@@ -187,43 +226,8 @@ class MPISharedTargets(object):
         # Allocate the shared buffer
         self._shared = MPIShared((self._bufsize,), self._dtype, self._comm)
 
-        # Now set the shared data buffer, one target at a time
-
-        targetnum = 0
-        for id, tdict in self._target_dictionary.items():
-            for spectra_label in ["spectra", "coadd"]:
-                specnum = 0
-                for spectra_dict in tdict[spectra_label]:
-                    target_begin = spectra_dict["wave"][0]
-                    target_end = spectra_dict["rshape"][1]
-                    target_buffer = None
-                    if root:
-                        assert targets[targetnum].id == id
-                        target_buffer = np.empty((target_end - target_begin,),
-                            dtype=np.float64)
-                        spectrum = None
-                        if spectra_label == "spectra":
-                            spectrum = targets[targetnum].spectra[specnum]
-                        elif spectra_label == "coadd":
-                            spectrum = targets[targetnum].coadd[specnum]
-                        for label, an_array in zip(["wave", "flux", "ivar", 
-                            "rdata", "roffsets", "rshape"], [spectrum.wave,
-                            spectrum.flux, spectrum.ivar, spectrum.R.data, 
-                            spectrum.R.offsets.astype(self._dtype),
-                            np.array(spectrum.R.shape).astype(self._dtype)]):
-                            begin = spectra_dict[label][0] - target_begin
-                            end = spectra_dict[label][1] - target_begin
-                            target_buffer[begin:end] = an_array.ravel()
-                    self._shared.set(target_buffer, (target_begin,), 
-                        fromrank=0)
-                    specnum += 1
-            targetnum += 1
-
-        # Wrap the target data in a friendlier format.  This will likely
-        # duplicate some data from the resolution matrix.
-
-        self.targets = self._get_targets()
-
+        self._targets = None
+        self._remapped = False
 
     def __del__(self):
         self.close()
@@ -238,56 +242,67 @@ class MPISharedTargets(object):
     def close(self):
         return
 
-
-    def _fill_target_dictionary(self, targets):
+    @property
+    def targets(self):
         """
-        Reads a list of targets, fills a dictionary containing
-        for each spectrum of each target, the indices of
-        the wave, flux, ivar, rdata, roffsets and rshape arrays in an array to be allocated.
-        The dictionary structure is
-        { target_id_1 : { "spectra" : [ {"wave" : [b,e] , "flux" : [b,e] ,  ....} , ... ]} , "coadd" : [ ... ]},  target_id_2 : ... },
-        i.e. a dictionary of targets identified by their id
-             - each target has two list of spectra labeled "spectra" and "coadd"
-             - each spectrum in the two lists of spectra is a dictionary containing, for the keys
-                "wave", "flux", "ivar", "rdata", "roffsets" and "rshape" , the begin and end index of the array in the shared 
-               memory buffer.
-        
+        Return the re-mapped target list.
+        """
+        if not self._remapped:
+            self._targets = self._get_targets()
+            self._remapped = True
+        return self._targets
+
+    @property
+    def target_offsets(self):
+        """
+        Return the target offset dictionary.
+        """
+        return self._target_dictionary
+
+    def insert(self, targets):
+        """
+        Copy the specified target data into the shared memory.
+
         Args:
             targets (list): the list of targets.
-
-        Returns:
-            - dictionnary
-            - size of the memory array
-        
         """
-        n = 0
-        dictionary = OrderedDict() # keep targets as ordered in list
-        for target in targets :
-            dictionary[target.id] = {}
-            for spectra_label, spectra in zip(["spectra", "coadd"], 
-                [target.spectra, target.coadd]):
-                spectra_list = list()
-                for spectrum in spectra :
-                    spectrum_dict = {}
-                    for label, asize in zip(["wave","flux","ivar","rdata",
-                        "roffsets","rshape"], [spectrum.wave.size, 
-                        spectrum.flux.size, spectrum.ivar.size, 
-                        spectrum.R.data.size, spectrum.R.offsets.size,
-                        len(spectrum.R.shape)]):
-                        spectrum_dict[label] = [n, n + asize]
-                        n += asize
-                    spectra_list.append(spectrum_dict)
-                dictionary[target.id][spectra_label] = spectra_list
-        return dictionary, n
-
+        for target in targets:
+            id = target.id
+            tdict = self._target_dictionary[id]
+            for spectra_label in ["spectra", "coadd"]:
+                specnum = 0
+                for spectra_dict in tdict[spectra_label]:
+                    target_begin = spectra_dict["wave"][0]
+                    target_end = spectra_dict["rshape"][1]
+                    target_buffer = None
+                    if root:
+                        target_buffer = np.empty((target_end - target_begin,),
+                            dtype=np.float64)
+                        spectrum = None
+                        if spectra_label == "spectra":
+                            spectrum = targets[id].spectra[specnum]
+                        elif spectra_label == "coadd":
+                            spectrum = targets[id].coadd[specnum]
+                        for label, an_array in zip(["wave", "flux", "ivar", 
+                            "rdata", "roffsets", "rshape"], [spectrum.wave,
+                            spectrum.flux, spectrum.ivar, spectrum.R.data, 
+                            spectrum.R.offsets.astype(self._dtype),
+                            np.array(spectrum.R.shape).astype(self._dtype)]):
+                            begin = spectra_dict[label][0] - target_begin
+                            end = spectra_dict[label][1] - target_begin
+                            target_buffer[begin:end] = an_array.ravel()
+                    self._shared.set(target_buffer, (target_begin,), 
+                        fromrank=0)
+                    specnum += 1
+        return
 
     def _get_targets(self):
         """
-        Generates a set of targets from a shared memory buffer, using self._target_dictionary
-        to get the list of target ids, the number spectra, and the addresses in the memory
-        of each array that defines a spectrum (wave, flux, ivar, rdata).
+        Generates a set of targets from a shared memory buffer, using
+        self._target_dictionary to get the list of target ids, the number
+        spectra, and the addresses in the memory of each array that defines
+        a spectrum (wave, flux, ivar, rdata).
         """
-        
         targets = list()
         for id, tdict in self._target_dictionary.items():
             spectra = list()
@@ -312,8 +327,45 @@ class MPISharedTargets(object):
         return targets
 
 
+def compute_coadd(spectra, spectrum_class=SimpleSpectrum):
+    coadd = list()
+    for key in set([s.wavehash for s in spectra]):
+        wave = None
+        unweightedflux = None
+        weightedflux = None
+        weights = None
+        R = None
+        nspec = 0
+        for s in spectra:
+            if s.wavehash != key: continue
+            nspec += 1
+            n = len(s.ivar)
+            if weightedflux is None:
+                wave = s.wave
+                unweightedflux = s.flux.copy()
+                weightedflux = s.flux * s.ivar
+                weights = s.ivar.copy()
+                W = scipy.sparse.dia_matrix((s.ivar, [0,]), (n,n))
+                weightedR = W * s.R
+            else:
+                unweightedflux += s.flux
+                weightedflux += s.flux * s.ivar
+                weights += s.ivar
+                W = scipy.sparse.dia_matrix((s.ivar, [0,]), (n,n))
+                weightedR += W * s.R
+
+        isbad = (weights == 0)
+        flux = weightedflux / (weights + isbad)
+        flux[isbad] = unweightedflux[isbad] / nspec
+        Winv = scipy.sparse.dia_matrix((1/(weights+isbad), [0,]), (n,n))
+        R = Winv * weightedR
+        R = R.todia()
+        coadd.append(spectrum_class(wave, flux, weights, R))
+    return coadd
+
+
 class Target(object):
-    def __init__(self, targetid, spectra, coadd=None,do_coadd = True):
+    def __init__(self, targetid, spectra, coadd=None, do_coadd=True):
         """
         Create a Target object
 
@@ -334,44 +386,13 @@ class Target(object):
             return
 
         if coadd is None:
-        #- Make a basic coadd
-            self.coadd = list()
-            for key in set([s.wavehash for s in spectra]):
-                wave = None
-                unweightedflux = None
-                weightedflux = None
-                weights = None
-                R = None
-                nspec = 0
-                for s in spectra:
-                    if s.wavehash != key: continue
-                    nspec += 1
-                    if weightedflux is None:
-                        wave = s.wave
-                        unweightedflux = s.flux.copy()
-                        weightedflux = s.flux * s.ivar
-                        weights = s.ivar.copy()
-                        n = len(s.ivar)
-                        W = scipy.sparse.dia_matrix((s.ivar, [0,]), (n,n))
-                        weightedR = W * s.R
-                    else:
-                        assert len(s.ivar) == n
-                        unweightedflux += s.flux
-                        weightedflux += s.flux * s.ivar
-                        weights += s.ivar
-                        W = scipy.sparse.dia_matrix((s.ivar, [0,]), (n,n))
-                        weightedR += W * s.R
-
-                isbad = (weights == 0)
-                flux = weightedflux / (weights + isbad)
-                flux[isbad] = unweightedflux[isbad] / nspec
-                Winv = scipy.sparse.dia_matrix((1/(weights+isbad), [0,]), (n,n))
-                R = Winv * weightedR
-                R = R.todia()
-                self.coadd.append(MultiprocessingSharedSpectrum(wave, flux, weights, R))
+            #- Make a basic coadd
+            compute_coadd(spectra, 
+                spectrum_class=MultiprocessingSharedSpectrum)
         else :
             self.coadd=coadd
-    
+
+
     def sharedmem_pack(self):
         '''Prepare underlying numpy arrays for sending to a new process;
         call self.sharedmem_unpack() to restore to original state.'''

--- a/py/redrock/dataobj.py
+++ b/py/redrock/dataobj.py
@@ -133,7 +133,8 @@ class SimpleSpectrum(object):
         self.flux=flux
         self.ivar=ivar
         self.R=R
-        self.Rcsr = self.R.tocsr()
+        self.Rcsr = R
+        #self.Rcsr = self.R.tocsr()
         self.wavehash = hash((len(wave), wave[0], wave[1], wave[-2], wave[-1]))
 
 

--- a/py/redrock/dataobj.py
+++ b/py/redrock/dataobj.py
@@ -127,14 +127,15 @@ class MultiprocessingSharedSpectrum(object):
 
 class SimpleSpectrum(object):
 
-    def __init__(self, wave, flux, ivar, R):
+    def __init__(self, wave, flux, ivar, R, Rcsr=None):
         self.nwave=wave.size
         self.wave=wave
         self.flux=flux
         self.ivar=ivar
         self.R=R
-        self.Rcsr = R
-        #self.Rcsr = self.R.tocsr()
+        self.Rcsr = Rcsr
+        if self.Rcsr is None:
+            self.Rcsr = self.R.tocsr()
         self.wavehash = hash((len(wave), wave[0], wave[1], wave[-2], wave[-1]))
 
 

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -753,9 +753,11 @@ class MPISharedTargetsDesi(MPISharedTargets):
                         speclist.append( SimpleSpectrum(wave_data, flux_data,
                             ivar_data, resdia, Rcsr=rescsr) )
 
-            # Create the Target from the list of spectra.  The
-            # coadd is created on construction.
-            targets.append(Target(id, speclist, coadd=None))
+            # Create the Target from the list of spectra.
+            # FIXME: we need to create the coadd as well and store it
+            # in shared memory, indexed by the target ID.  Then we need
+            # to pass that to the Target constructor.
+            targets.append(Target(id, speclist, coadd=None, do_coadd=False))
 
         return targets
 

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -395,7 +395,6 @@ class MPISharedTargetsDesi(MPISharedTargets):
                     dims = hdus[h].data.shape
                     if len(dims) == 2 and dims[1] == 0:
                         dims = (dims[0],)
-                    print("hdu {} {} has dims {}".format(h, hdus[h].header["EXTNAME"], dims), flush=True)
                 if self._comm is not None:
                     dims = self._comm.bcast(dims, root=0)
 
@@ -406,7 +405,6 @@ class MPISharedTargetsDesi(MPISharedTargets):
                     indata = None
                     if self._root:
                         indata = hdus[h].data.astype(np.float64)
-                        print("data {} has shape {}".format(h, indata.shape), flush=True)
                     self._raw[sfile][name].set(indata, (0,), 
                         fromrank=0)
 
@@ -431,7 +429,6 @@ class MPISharedTargetsDesi(MPISharedTargets):
                         resshape = testres.shape
                         resoffsize = len(testres.offsets.ravel())
                         resdatasize = len(testres.data.ravel())
-                        print("res data dims = {},{}".format(len(rows), resoffsize + resdatasize), flush=True)
                     if self._comm is not None:
                         resshape = self._comm.bcast(resshape, root=0)
                         resoffsize = self._comm.bcast(resoffsize, root=0)
@@ -496,16 +493,10 @@ class MPISharedTargetsDesi(MPISharedTargets):
             for sfile in self._spectrafiles:
                 if id not in self._target_specs[sfile]:
                     # nothing in this file
-                    if self._root:
-                        print("skipping id {}, not in file".format(id), flush=True)
                     continue
                 rows = self._target_specs[sfile][id]
-                if self._root:
-                    print("id {} in rows {}".format(id, ",".join(["{}".format(x) for x in rows ])),flush=True)
                 for row in rows:
                     memrow = self._spec_sliced[sfile][row]
-                    if self._root:
-                        print("Building spec wrapper for {}, row {}, memrow {}".format(id, row, memrow), flush=True)
                     for band in self._bands[sfile]:
                         wave_name = "{}_WAVELENGTH".format(band.upper())
                         flux_name = "{}_FLUX".format(band.upper())

--- a/py/redrock/sharedmem_mpi.py
+++ b/py/redrock/sharedmem_mpi.py
@@ -253,8 +253,7 @@ class MPIShared(object):
             if comm.rank == 0:
                 print("MPIShared: one or more processes failed: {}".format(
                     msg))
-                sys.stdout.flush()
-                comm.Abort()
+            comm.Abort()
         return
 
 
@@ -291,27 +290,32 @@ class MPIShared(object):
 
         if self._rank == fromrank:
             if len(data.shape) != len(self._shape):
-                msg = "data has incompatible number of dimensions"
+                if len(data.shape) != len(self._shape):
+                    msg = "input data dimensions {} incompatible with "\
+                        "buffer ({})".format(len(data.shape), len(self._shape))
                 if self._comm is not None:
                     print(msg)
                     sys.stdout.flush()
-                    #self._comm.Abort()
+                    self._comm.Abort()
                 else:
                     raise RuntimeError(msg)
             if len(offset) != len(self._shape):
-                msg = "offset tuple has incompatible number of dimensions"
+                msg = "input offset dimensions {} incompatible with "\
+                    "buffer ({})".format(len(offset), len(self._shape))
                 if self._comm is not None:
                     print(msg)
                     sys.stdout.flush()
-                    #self._comm.Abort()
+                    self._comm.Abort()
                 else:
                     raise RuntimeError(msg)
             if data.dtype != self._dtype:
-                msg = "input data has different type than shared array"
+                msg = "input data type ({}, {}) incompatible with "\
+                    "buffer ({}, {})".format(data.dtype.str, data.dtype.num,
+                    self._dtype.str, self._dtype.num)
                 if self._comm is not None:
                     print(msg)
                     sys.stdout.flush()
-                    #self._comm.Abort()
+                    self._comm.Abort()
                 else:
                     raise RuntimeError(msg)
 


### PR DESCRIPTION
This implements a new desi variant of the MPISharedTargets class which loads one or more spectra files directly into MPI shared memory.  The list of spectra for each target is then constructed with references into the shared memory.  For now, we have disable the creation of the CSR version of the resolution matrix.  This could be re-enabled and stored in shared memory if needed.