### PR TITLE
Refactor io

### DIFF
--- a/py/redrock/dataobj.py
+++ b/py/redrock/dataobj.py
@@ -62,6 +62,24 @@ class Template(object):
         flux = self.flux.T.dot(coeff).T / (1+z)
         return trapz_rebin(self.wave*(1+z), flux, wave)
 
+    def add_broadband(self,degree):
+        '''
+        Add polynomial terms to this templates.
+        The templates will be added as if they were PCA components.
+        '''
+        if hasattr(self,'broadband'):
+            raise Exception("Multiple calls to broadband not allowed")
+
+        self.broadband = True
+        wave = (self.wave-self.wave.min())/(self.wave.max()-self.wave.min())
+        norm = self.flux[0].sum()
+        for deg in range(degree+1):
+            bb = wave**deg
+            ## adjust the normalization to the first PCA component:
+            bb *= norm/bb.sum()
+
+            self.flux = np.vstack((self.flux,bb))
+            self.nbasis += 1
         
 class MultiprocessingSharedSpectrum(object):
 

--- a/py/redrock/dataobj.py
+++ b/py/redrock/dataobj.py
@@ -62,25 +62,6 @@ class Template(object):
         flux = self.flux.T.dot(coeff).T / (1+z)
         return trapz_rebin(self.wave*(1+z), flux, wave)
 
-    def add_broadband(self,degree):
-        '''
-        Add polynomial terms to this templates.
-        The templates will be added as if they were PCA components.
-        '''
-        if hasattr(self,'broadband'):
-            raise Exception("Multiple calls to broadband not allowed")
-
-        self.broadband = True
-        wave = (self.wave-self.wave.min())/(self.wave.max()-self.wave.min())
-        norm = self.flux[0].sum()
-        for deg in range(degree+1):
-            bb = wave**deg
-            ## adjust the normalization to the first PCA component:
-            bb *= norm/bb.sum()
-
-            self.flux = np.vstack((self.flux,bb))
-            self.nbasis += 1
-        
 class MultiprocessingSharedSpectrum(object):
 
     def __init__(self, wave, flux, ivar, R):

--- a/py/redrock/dataobj.py
+++ b/py/redrock/dataobj.py
@@ -62,6 +62,7 @@ class Template(object):
         flux = self.flux.T.dot(coeff).T / (1+z)
         return trapz_rebin(self.wave*(1+z), flux, wave)
 
+
 class MultiprocessingSharedSpectrum(object):
 
     def __init__(self, wave, flux, ivar, R):

--- a/py/redrock/io.py
+++ b/py/redrock/io.py
@@ -53,19 +53,29 @@ def read_template(filename):
         wave = 10**wave
 
     flux = native_endian(fx['BASIS_VECTORS'].data)
+
+    ## find out if redshift info is present in the file
+    old_style_templates = True
+    try:
+        redshifts = native_endian(fx['REDSHIFTS'].data)
+        old_style_templates = False
+    except:
+        print("Can't find redshift range info in template file {}, using default values".format(filename))
+
     fx.close()
 
     rrtype = hdr['RRTYPE'].strip().upper()
-    if rrtype == 'GALAXY':
-        ### redshifts = 10**np.arange(np.log10(1+0.005), np.log10(1+2.0), 1.5e-4) - 1
-        redshifts = 10**np.arange(np.log10(1+0.005), np.log10(1+1.7), 3e-4) - 1
-    elif rrtype == 'STAR':
-        redshifts = np.arange(-0.002, 0.00201, 4e-5)
-    elif rrtype == 'QSO':
-        redshifts = 10**np.arange(np.log10(1+0.5), np.log10(1+4.0), 5e-4) - 1
-        redshifts = 10**np.arange(np.log10(1+0.5), np.log10(1+4.0), 5e-4) - 1
-    else:
-        raise ValueError('Unknown redshift range to use for template type {}'.format(rrtype))
+
+    if old_style_templates:
+        if rrtype == 'GALAXY':
+            ### redshifts = 10**np.arange(np.log10(1+0.005), np.log10(1+2.0), 1.5e-4) - 1
+            redshifts = 10**np.arange(np.log10(1+0.005), np.log10(1+1.7), 3e-4) - 1
+        elif rrtype == 'STAR':
+            redshifts = np.arange(-0.002, 0.00201, 4e-5)
+        elif rrtype == 'QSO':
+            redshifts = 10**np.arange(np.log10(1+0.5), np.log10(1+4.0), 5e-4) - 1
+        else:
+            raise ValueError('Unknown redshift range to use for template type {}'.format(rrtype))
 
     if 'RRSUBTYP' in hdr:
         subtype = hdr['RRSUBTYP'].strip().upper()
@@ -109,12 +119,14 @@ def read_templates(template_list=None, template_dir=None):
     if template_list is None:
         template_list = find_templates(template_dir)
 
-    templates = list()
+    templates = {}
     if isinstance(template_list, basestring):
-        templates.append(read_template(template_list))
+        t = read_template(template_list)
+        templates[t.fulltype] = t
     else:
         for tfile in template_list:
-            templates.append(read_template(tfile))
+            t = read_template(tfile)
+            templates[t.fulltype] = t
     
     if len(templates) == 0:
         raise IOError('No templates found')

--- a/py/redrock/io.py
+++ b/py/redrock/io.py
@@ -60,7 +60,7 @@ def read_template(filename):
         redshifts = native_endian(fx['REDSHIFTS'].data)
         old_style_templates = False
     except:
-        print("Can't find redshift range info in template file {}, using default values".format(filename))
+        print("INFO: Can't find redshift range info in template file {}, using default values".format(filename))
 
     fx.close()
 

--- a/py/redrock/plotspec.py
+++ b/py/redrock/plotspec.py
@@ -87,10 +87,11 @@ class PlotSpec(object):
         zz = zfit[zfit['znum'] == self.znum][0]
         coeff = zz['coeff']
 
-        for tp in self.templates:
-            if (tp.type == zz['spectype']) & (tp.subtype == zz['subtype']):
-                break
-    
+        fulltype = zz['spectype']
+        if zz['subtype'] != '':
+            fulltype = fulltype+":"+zz['subtype']
+        tp = self.templates[fulltype]
+
         if tp.type != zz['spectype']:
             raise ValueError('spectype {} not in templates'.format(zz['spectype']))
 

--- a/py/redrock/test/test_io.py
+++ b/py/redrock/test/test_io.py
@@ -45,7 +45,7 @@ class TestIO(unittest.TestCase):
         
     ### @unittest.skipIf('RR_TEMPLATE_DIR' not in os.environ, '$RR_TEMPLATE_DIR not set')
     def test_read_templates(self):
-        for template in rrio.read_templates():
+        for template in rrio.read_templates().values():
             self.assertIn('wave', template.__dict__)
             self.assertIn('flux', template.__dict__)
             self.assertIn('type', template.__dict__)
@@ -61,7 +61,7 @@ class TestIO(unittest.TestCase):
         t2 = util.get_target(0.5)
         t2.id = 222
         template = util.get_template(subtype='BLAT')
-        zscan1, zfit1 = rrzfind([t1,t2], [template,], ncpu=1)
+        zscan1, zfit1 = rrzfind([t1,t2], {template.fulltype:template}, ncpu=1)
 
         rrio.write_zscan(self.testfile, zscan1, zfit1)
         rrio.write_zscan(self.testfile, zscan1, zfit1, clobber=True)

--- a/py/redrock/test/test_zscan.py
+++ b/py/redrock/test/test_zscan.py
@@ -37,7 +37,7 @@ class TestZScan(unittest.TestCase):
         t2 = util.get_target(z2); t2.id = 222
         template = util.get_template()
         template.redshifts = np.linspace(0.15, 0.3, 50)
-        zscan, zfit = rrzfind([t1,t2], [template,], ncpu=1)
+        zscan, zfit = rrzfind([t1,t2], {template.fulltype:template}, ncpu=1)
 
         zx1 = zfit[zfit['targetid'] == 111][0]
         zx2 = zfit[zfit['targetid'] == 222][0]
@@ -86,7 +86,7 @@ class TestZScan(unittest.TestCase):
         Fstar.redshifts = np.linspace(-1e-3, 1e-3, 25)
         Fstar.redshifts = np.linspace(-1e-3, 1e-3, 25)
         nminima = 3
-        zscan, zfit = rrzfind([t1,t2], [Fstar, Mstar,], ncpu=1, 
+        zscan, zfit = rrzfind([t1,t2], {Fstar.fulltype:Fstar, Mstar.fulltype:Mstar}, ncpu=1, 
             nminima=nminima)
         self.assertEqual(len(zfit), 2*nminima)
         self.assertTrue(np.all(zfit['spectype'] == 'STAR'))

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -31,7 +31,7 @@ def zfind(targets, templates, ncpu=None, comm=None, nminima=3):
     
     Args:
         targets : list of Target objects
-        templates: list of Template objects
+        templates: dictionary of Template objects (template_name: template)
 
     Options:
         ncpu: number of CPU cores to use for multiprocessing
@@ -55,7 +55,7 @@ def zfind(targets, templates, ncpu=None, comm=None, nminima=3):
     zscan = dict()
     for target in targets:
         zscan[target.id] = dict()
-        for t in templates:
+        for t in templates.values():
             zscan[target.id][t.fulltype] = dict()
             
     if ncpu is None :
@@ -74,7 +74,7 @@ def zfind(targets, templates, ncpu=None, comm=None, nminima=3):
     else:
         print("INFO: not using multiprocessing")
         
-    for t in templates:
+    for t in templates.values():
 
         if comm is not None and (comm.rank == 0) :
             print('INFO: starting zchi2 scan for {}'.format(comm.rank,


### PR DESCRIPTION
This PR addresses issue #38 

Summary of the changes:
 * the function read_template tries to find the redshift range from the template file. It defaults to the original hardcoded if it fails. This change will allow users to add templates for spectra different than the current hardcoded classes.
 * the function read_templates puts the templates in a dictionary instead of a list. This is useful when running redrock interactively: to find a template in a list (e.g. to make a plot) one needs a loop, while one cat directly get it in a dictionary (e.g. templates['QSO'])
 * changing the templates to a dictionary implies minor changes down the road: wherever it said "templates" now it says "templates.values()"