### PR TITLE
set ivar=0 to masked pixels

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,11 @@ Redrock change log
 0.6.1 (unreleased)
 ------------------
 
-* No changes yet.
+* set ivar = 0 where mask != 0 (PR `#42`_)
 
-0.6.0 (unreleased)
+.. _`#42`: https://github.com/desihub/desispec/pull/42
+
+0.6.0 (2017-11-10)
 ------------------
 
 * adds rrboss to process boss spectra (PR `#37`_)

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -181,7 +181,7 @@ def read_bricks(brickfiles, trueflux=False, targetids=None, spectrum_class=Simpl
             else:
                 brickname = 'unknown'
             flux = brick.flux[ii]
-            ivar = brick.ivar[ii]
+            ivar = brick.ivar[ii] * (brick.mask[ii]==0)
             Rdata = brick.resolution_data[ii]
 
             #- work around desispec.io.Brick returning 32-bit non-native endian

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -94,7 +94,7 @@ def read_spectra(spectrafiles, targetids=None, spectrum_class=SimpleSpectrum):
             for x in sp.bands:          #- typically 'b', 'r', 'z'
                 wave = sp.wave[x]                
                 flux = sp.flux[x][ii]
-                ivar = sp.ivar[x][ii]
+                ivar = sp.ivar[x][ii]*(sp.mask[x][ii]==0)
                 Rdata = sp.resolution_data[x][ii]
 
                 for i in range(flux.shape[0]):


### PR DESCRIPTION
 PR to fix one issue that was considerably lowering the redshift efficiency for simulated data with cosmic rays: 
set ivar=0 to masked pixels. This might also change the BOSS/eBOSS redshift efficiencies.


