### PR TITLE
Add NUMTILE, NUMEXP to zbest output

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -9,6 +9,7 @@ Redrock change log
 * API CHANGE: redrock.io.read_templates() returns dict not list (PR `#41`_)
 * set ivar = 0 where mask != 0 (PR `#42`_)
 * Add NUMEXP and NUMTILE to zbest output
+* Propagate input fibermap into output zbest
 
 .. _`#41`: https://github.com/desihub/desispec/pull/41
 .. _`#42`: https://github.com/desihub/desispec/pull/42

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,12 +2,13 @@
 Redrock change log
 ==================
 
-0.6.1 (unreleased)
+0.7.0 (unreleased)
 ------------------
 
 * Allow templates to optionally include redshift range (PR `#41`_)
 * API CHANGE: redrock.io.read_templates() returns dict not list (PR `#41`_)
 * set ivar = 0 where mask != 0 (PR `#42`_)
+* Add NUMEXP and NUMTILE to zbest output
 
 .. _`#41`: https://github.com/desihub/desispec/pull/41
 .. _`#42`: https://github.com/desihub/desispec/pull/42

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,11 +8,12 @@ Redrock change log
 * Allow templates to optionally include redshift range (PR `#41`_)
 * API CHANGE: redrock.io.read_templates() returns dict not list (PR `#41`_)
 * set ivar = 0 where mask != 0 (PR `#42`_)
-* Add NUMEXP and NUMTILE to zbest output
-* Propagate input fibermap into output zbest
+* Add NUMEXP and NUMTILE to zbest output (PR `#59`_)
+* Propagate input fibermap into output zbest (PR `#59`_)
 
 .. _`#41`: https://github.com/desihub/desispec/pull/41
 .. _`#42`: https://github.com/desihub/desispec/pull/42
+.. _`#59`: https://github.com/desihub/desispec/pull/59
 
 0.6.0 (2017-11-10)
 ------------------

--- a/py/redrock/dataobj.py
+++ b/py/redrock/dataobj.py
@@ -65,7 +65,7 @@ class Template(object):
 
 class MultiprocessingSharedSpectrum(object):
 
-    def __init__(self, wave, flux, ivar, R):
+    def __init__(self, wave, flux, ivar, R, meta=dict()):
         """
         create a Spectrum object
         
@@ -86,6 +86,7 @@ class MultiprocessingSharedSpectrum(object):
         self._shmem['ivar'] = sharedmem.fromarray(ivar)
         self._shmem['R.data'] = sharedmem.fromarray(R.data)
         self._shmem['R.offsets'] = R.offsets
+        self.meta = meta
 
         self._shmem['R.shape'] = R.shape
         
@@ -127,7 +128,7 @@ class MultiprocessingSharedSpectrum(object):
 
 class SimpleSpectrum(object):
 
-    def __init__(self, wave, flux, ivar, R):
+    def __init__(self, wave, flux, ivar, R, meta=dict()):
         self.nwave=wave.size
         self.wave=wave
         self.flux=flux
@@ -135,6 +136,7 @@ class SimpleSpectrum(object):
         self.R=R
         self.Rcsr = self.R.tocsr()
         self.wavehash = hash((len(wave), wave[0], wave[1], wave[-2], wave[-1]))
+        self.meta = meta
 
 
 class MPISharedTargets(object):
@@ -313,7 +315,7 @@ class MPISharedTargets(object):
 
 
 class Target(object):
-    def __init__(self, targetid, spectra, coadd=None,do_coadd = True):
+    def __init__(self, targetid, spectra, coadd=None, do_coadd=True, meta=dict()):
         """
         Create a Target object
 
@@ -326,9 +328,12 @@ class Target(object):
                     It is needed to create a new Target object from a shared memory buffer, because 
                     the Target object that was stored in the buffer had its coadd precomputed, 
                     and we don't want to reallocate memory or compute the coadds twice.
+            do_coadd: perform the coadd
+            meta: optional metadata dictionary to associate with this target
         """
         self.id = targetid
         self.spectra = spectra
+        self.meta = meta
 
         if not do_coadd:
             return

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -107,6 +107,20 @@ def read_spectra(spectrafiles, targetids=None, spectrum_class=SimpleSpectrum):
                         continue
 
                     R = Resolution(Rdata[i])
+
+                    meta = dict()
+                    meta['NIGHT'] = sp.meta['NIGHT']
+                    meta['EXPID'] = sp.meta['EXPID']
+                    if 'HPXPIXEL' in sp.meta:
+                        meta['HPXPIXEL'] = sp.meta['HPXPIXEL']
+                        meta['HPXNSIDE'] = sp.meta['HPXNSIDE']
+                    else:
+                        import desimodel.footprint
+                        meta['HPXNSIDE'] = 64
+                        ra = sp.fibermap['RA_TARGET'][ii[i]]
+                        dec = sp.fibermap['DEC_TARGET'][ii[i]]
+                        meta['HPXPIXEL'] = desimodel.footprint.radec2pix(64, ra, dec)
+
                     spectra.append(spectrum_class(wave, flux[i], ivar[i], R))
 
         bricknames.append(brickname)
@@ -331,6 +345,14 @@ def rrdesi(options=None, comm=None):
 
             #- Add brickname column
             zbest['BRICKNAME'] = meta['BRICKNAME']
+
+            #- Move TARGETID to be first column as primary key
+            zbest.columns.move_to_end('TARGETID', last=False)
+
+            #--- DEBUG ---
+            import IPython
+            IPython.embed()
+            #--- DEBUG ---
 
             print('INFO: writing {}'.format(opts.zbest))
             write_zbest(opts.zbest, zbest)

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -147,7 +147,7 @@ def read_spectra(spectrafiles, targetids=None, spectrum_class=SimpleSpectrum):
             meta = dict(NUMEXP=numexp, NUMTILE=numtile)
             targets.append(Target(targetid, spectra, meta=meta))
         else:
-            print('ERROR: Target {} on {} has no good spectra'.format(targetid, os.path.basename(brickfiles[0])))
+            print('ERROR: Target {} on {} has no good spectra'.format(targetid, os.path.basename(spectrafiles[0])))
 
     fibermap = vstack(input_fibermaps)
 
@@ -193,7 +193,7 @@ def rrdesi(options=None, comm=None):
         sys.exit(1)
 
     if len(infiles) == 0:
-        print('ERROR: must provide input spectra/brick files')
+        print('ERROR: must provide input spectra files')
         sys.exit(1)
 
     templates = None

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -117,7 +117,7 @@ def read_spectra(spectrafiles, targetids=None, spectrum_class=SimpleSpectrum):
 
                     if 'HPXPIXEL' in sp.fibermap.dtype.names:
                         meta['HPXPIXEL'] = sp.fibermap['HPXPIXEL'][ifiber]
-                        meta['HPXNSIDE'] = sp.fibermap['HPXNSIDE'][ifiber]
+                        meta['HPXNSIDE'] = sp.meta['HPXNSIDE']
                     else:
                         import desimodel.footprint
                         meta['HPXNSIDE'] = 64

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -91,17 +91,12 @@ def read_spectra(spectrafiles, targetids=None, spectrum_class=SimpleSpectrum):
         targetids = input_targetids
 
     targets = list()
-    bricknames = list()
     for targetid in targetids:
         spectra = list()
         for sp in input_spectra:
             ii = np.where(sp.fibermap['TARGETID'] == targetid)[0]
             if np.count_nonzero(ii) == 0:
                 continue
-            if 'BRICKNAME' in sp.fibermap.dtype.names:
-                brickname = sp.fibermap['BRICKNAME'][ii][0]
-            else:
-                brickname = 'unknown'
             for x in sp.bands:          #- typically 'b', 'r', 'z'
                 wave = sp.wave[x]                
                 flux = sp.flux[x][ii]
@@ -111,11 +106,9 @@ def read_spectra(spectrafiles, targetids=None, spectrum_class=SimpleSpectrum):
                 for i in range(flux.shape[0]):
                     ifiber = ii[i]      #- index into sp.fibermap
                     if np.all(flux[i] == 0):
-                        # print('WARNING: Skipping spectrum {} of target {} on brick {} with flux=0'.format(i, targetid, brick.brickname))
                         continue
 
                     if np.all(ivar[i] == 0):
-                        # print('WARNING: Skipping spectrum {} of target {} on brick {} with ivar=0'.format(i, targetid, brick.brickname))
                         continue
 
                     R = Resolution(Rdata[i])
@@ -142,7 +135,6 @@ def read_spectra(spectrafiles, targetids=None, spectrum_class=SimpleSpectrum):
 
                     spectra.append(spectrum_class(wave, flux[i], ivar[i], R, meta=meta))
 
-        bricknames.append(brickname)
         #- end of for targetid in targetids loop
 
         if len(spectra) > 0:
@@ -156,13 +148,6 @@ def read_spectra(spectrafiles, targetids=None, spectrum_class=SimpleSpectrum):
             targets.append(Target(targetid, spectra, meta=meta))
         else:
             print('ERROR: Target {} on {} has no good spectra'.format(targetid, os.path.basename(brickfiles[0])))
-
-    #- Create a metadata table in case we might want to add other columns
-    #- in the future
-    assert len(bricknames) == len(targets)
-    dtype = [('BRICKNAME', 'S8'),]
-    meta = np.zeros(len(bricknames), dtype=dtype)
-    meta['BRICKNAME'] = bricknames
 
     fibermap = vstack(input_fibermaps)
 

--- a/py/redrock/io.py
+++ b/py/redrock/io.py
@@ -60,7 +60,7 @@ def read_template(filename):
         redshifts = native_endian(fx['REDSHIFTS'].data)
         old_style_templates = False
     except:
-        print("INFO: Can't find redshift range info in template file {}, using default values".format(filename))
+        print("DEBUG: Can't find redshift range info in template file {}, using default values".format(filename))
 
     fx.close()
 


### PR DESCRIPTION
Fixes #24 by adding NUMTILE and NUMEXP columns to zbest output.  Also propagates input fibermap from spectra file into output zbest file to allow matching targets/redshifts back to exposures.  Deprecates reading brick files.  Tested on 44k targets in 46 spectra files using minitest notebook.

This is the last (?) redrock change prior to the desimodules 17.12 release and prior to a major structural refactor by Ted to incorporate MPI more cleanly, so I plan to self merge after test pass (and after lunch...).