### PR TITLE
Read sdss templates

### DIFF
--- a/bin/rrconvertSDSStemplates
+++ b/bin/rrconvertSDSStemplates
@@ -31,7 +31,6 @@ def convert():
         name_mode = True
     else:
         nb_templates = 1
-        eigen_mode = True
 
     ###
     for s in range(nb_templates):

--- a/bin/rrconvertSDSStemplates
+++ b/bin/rrconvertSDSStemplates
@@ -69,12 +69,3 @@ def convert():
     return
 
 convert()
-
-
-
-
-
-
-
-
-

--- a/bin/rrconvertSDSStemplates
+++ b/bin/rrconvertSDSStemplates
@@ -2,13 +2,18 @@
 
 import sys
 import scipy as sp
+import optparse
 from astropy.io import fits
 
 def convert():
 
+    parser = optparse.OptionParser(usage = "%prog [options]")
+    parser.add_option("-i", "--infile", type="string",  help="input SDSS templates")
+    parser.add_option("-o", "--outpath", type="string",  help="output filename")
+    opts, args = parser.parse_args()
+
     ###
-    p = sys.argv[1]
-    cat = fits.open(p)
+    cat = fits.open(opts.infile)
 
     if len(cat)!=1:
         print("ERROR: FITS file has more than 1 header")
@@ -45,7 +50,7 @@ def convert():
         header['RRTYPE']   = spectype
         header['RRSUBTYP'] = subtype
         header['RRVER']    = ""
-        header['INSPEC']   = p
+        header['INSPEC']   = opts.infile
         header['EXTNAME']  = "BASIS_VECTORS"
 
         ###
@@ -58,9 +63,9 @@ def convert():
         subtype  = subtype.replace(" ","")
         spectype = spectype.lower()
         if name_mode:
-            outfile = "Templates/rrtemplate-"+spectype+"-"+subtype+".fits"
+            outfile = opts.outpath+"/rrtemplate-"+spectype+"-"+subtype+".fits"
         elif eigen_mode:
-            outfile = "Templates/rrtemplate-"+spectype+".fits"
+            outfile = opts.outpath+"/rrtemplate-"+spectype+".fits"
         hdus.writeto(outfile, overwrite=True)
         print('RR: Wrote '+outfile)
 

--- a/bin/rrconvertSDSStemplates
+++ b/bin/rrconvertSDSStemplates
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import sys
+import re
 import scipy as sp
 import optparse
 from astropy.io import fits
@@ -56,6 +57,10 @@ def convert():
         header['INSPEC']   = opts.infile
         header['EXTNAME']  = "BASIS_VECTORS"
 
+        rx = re.search('\((\d+)\)$', subtype)
+        if rx:
+            header['INDOUSID'] = (int(rx.groups()[0]), 'Indo-US stellar template ID')
+
         ###
         if name_mode:
             hdus.append(fits.PrimaryHDU(sp.asarray([cat[0].data[s,:]]), header=header))
@@ -63,10 +68,10 @@ def convert():
             hdus.append(fits.PrimaryHDU(sp.asarray(cat[0].data), header=header))
 
         ###
-        subtype  = subtype.replace(" ","")
         spectype = spectype.lower()
         if name_mode:
-            outfile = opts.outfolder+"/rrtemplate-"+spectype+"-"+subtype+".fits"
+            filesubtype = subtype.replace(' ', '').replace('(', '_').replace(')', '')
+            outfile = opts.outfolder+"/rrtemplate-"+spectype+"-"+filesubtype+".fits"
         else:
             outfile = opts.outfolder+"/rrtemplate-"+spectype+".fits"
         hdus.writeto(outfile, overwrite=True)

--- a/bin/rrconvertSDSStemplates
+++ b/bin/rrconvertSDSStemplates
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+import sys
+import scipy as sp
+from astropy.io import fits
+
+def convert():
+
+    ###
+    p = sys.argv[1]
+    cat = fits.open(p)
+
+    if len(cat)!=1:
+        print("ERROR: FITS file has more than 1 header")
+        return
+
+    ###
+    name_mode = False
+    eigen_mode = False
+    if "NAME0" in cat[0].header:
+        nb_templates = len([el for el in cat[0].header if len(el)>4 and el[:4]=="NAME"])
+        name_mode = True
+    elif "EIGEN0" in cat[0].header:
+        nb_templates = 1
+        eigen_mode = True
+    else:
+        print("ERROR: FITS file has no 'NAME' nor 'EIGEN'")
+        return
+
+    ###
+    for s in range(nb_templates):
+
+        spectype = cat[0].header["OBJECT"].replace(" ","").upper()
+        if name_mode:
+            subtype = cat[0].header["NAME"+str(s)].replace("-","").replace("/","")
+        elif eigen_mode:
+            subtype = ""
+
+        ###
+        hdus = fits.HDUList()
+        header = fits.Header()
+        header['CRVAL1']   = cat[0].header["COEFF0"]
+        header['CDELT1']   = cat[0].header["COEFF1"]
+        header['LOGLAM']   = 1
+        header['RRTYPE']   = spectype
+        header['RRSUBTYP'] = subtype
+        header['RRVER']    = ""
+        header['INSPEC']   = p
+        header['EXTNAME']  = "BASIS_VECTORS"
+
+        ###
+        if name_mode:
+            hdus.append(fits.PrimaryHDU(sp.asarray([cat[0].data[s,:]]), header=header))
+        elif eigen_mode:
+            hdus.append(fits.PrimaryHDU(sp.asarray(cat[0].data), header=header))
+
+        ###
+        subtype  = subtype.replace(" ","")
+        spectype = spectype.lower()
+        if name_mode:
+            outfile = "Templates/rrtemplate-"+spectype+"-"+subtype+".fits"
+        elif eigen_mode:
+            outfile = "Templates/rrtemplate-"+spectype+".fits"
+        hdus.writeto(outfile, overwrite=True)
+        print('RR: Wrote '+outfile)
+
+    cat.close()
+
+    return
+
+convert()
+
+
+
+
+
+
+
+
+

--- a/bin/rrconvertSDSStemplates
+++ b/bin/rrconvertSDSStemplates
@@ -41,7 +41,8 @@ def convert():
             print("WARNING: spectype is not a known redrock spectype: "+spectype)
 
         if name_mode:
-            subtype = cat[0].header["NAME"+str(s)].replace("-","").replace("/","")
+            header_name = cat[0].header["NAME"+str(s)]
+            subtype = header_name.replace("-","").replace("/","")
         else:
             subtype = ""
 
@@ -53,13 +54,16 @@ def convert():
         header['LOGLAM']   = 1
         header['RRTYPE']   = spectype
         header['RRSUBTYP'] = subtype
-        header['RRVER']    = redrock.__version__
-        header['INSPEC']   = opts.infile
-        header['EXTNAME']  = "BASIS_VECTORS"
-
+        if name_mode:
+            header['SDSSNAME'] = (header_name, 'Orig NAMEnn keyword')
         rx = re.search('\((\d+)\)$', subtype)
         if rx:
             header['INDOUSID'] = (int(rx.groups()[0]), 'Indo-US stellar template ID')
+
+        header['RRVER']    = redrock.__version__
+        header['INSPEC']   = opts.infile
+        header['EXTNAME']  = "BASIS_VECTORS"
+        header.add_comment('Converted from SDSS template format')
 
         ###
         if name_mode:

--- a/bin/rrconvertSDSStemplates
+++ b/bin/rrconvertSDSStemplates
@@ -4,41 +4,45 @@ import sys
 import scipy as sp
 import optparse
 from astropy.io import fits
+import redrock
 
 def convert():
 
     parser = optparse.OptionParser(usage = "%prog [options]")
-    parser.add_option("-i", "--infile", type="string",  help="input SDSS templates")
-    parser.add_option("-o", "--outpath", type="string",  help="output filename")
+    parser.add_option("-i", "--infile", type="string", help="input SDSS templates")
+    parser.add_option("-o", "--outfolder", type="string", help="output folder")
     opts, args = parser.parse_args()
 
     ###
     cat = fits.open(opts.infile)
 
-    if len(cat)!=1:
-        print("ERROR: FITS file has more than 1 header")
+    if "OBJECT" not in cat[0].header or "COEFF0" not in cat[0].header:
+        print("ERROR: FITS file has no 'OBJECT' or 'COEFF0': "+opts.infile)
+        cat.close()
         return
 
+    if len(cat)!=1:
+        print("WARNING: FITS file has more than 1 header: "+opts.infile)
+
     ###
-    name_mode = False
-    eigen_mode = False
+    name_mode  = False
     if "NAME0" in cat[0].header:
         nb_templates = len([el for el in cat[0].header if len(el)>4 and el[:4]=="NAME"])
         name_mode = True
-    elif "EIGEN0" in cat[0].header:
+    else:
         nb_templates = 1
         eigen_mode = True
-    else:
-        print("ERROR: FITS file has no 'NAME' nor 'EIGEN'")
-        return
 
     ###
     for s in range(nb_templates):
 
         spectype = cat[0].header["OBJECT"].replace(" ","").upper()
+        if spectype not in ["STAR","GALAXY","QSO"]:
+            print("WARNING: spectype is not a known redrock spectype: "+spectype)
+
         if name_mode:
             subtype = cat[0].header["NAME"+str(s)].replace("-","").replace("/","")
-        elif eigen_mode:
+        else:
             subtype = ""
 
         ###
@@ -49,23 +53,23 @@ def convert():
         header['LOGLAM']   = 1
         header['RRTYPE']   = spectype
         header['RRSUBTYP'] = subtype
-        header['RRVER']    = ""
+        header['RRVER']    = redrock.__version__
         header['INSPEC']   = opts.infile
         header['EXTNAME']  = "BASIS_VECTORS"
 
         ###
         if name_mode:
             hdus.append(fits.PrimaryHDU(sp.asarray([cat[0].data[s,:]]), header=header))
-        elif eigen_mode:
+        else:
             hdus.append(fits.PrimaryHDU(sp.asarray(cat[0].data), header=header))
 
         ###
         subtype  = subtype.replace(" ","")
         spectype = spectype.lower()
         if name_mode:
-            outfile = opts.outpath+"/rrtemplate-"+spectype+"-"+subtype+".fits"
-        elif eigen_mode:
-            outfile = opts.outpath+"/rrtemplate-"+spectype+".fits"
+            outfile = opts.outfolder+"/rrtemplate-"+spectype+"-"+subtype+".fits"
+        else:
+            outfile = opts.outfolder+"/rrtemplate-"+spectype+".fits"
         hdus.writeto(outfile, overwrite=True)
         print('RR: Wrote '+outfile)
 

--- a/py/redrock/external/boss.py
+++ b/py/redrock/external/boss.py
@@ -309,14 +309,14 @@ def rrboss(options=None, comm=None):
     if args.targetids is not None:
         targetids = [ int(x) for x in args.targetids.split(",") ]
 
-    n_target = None
+    n_targets = None
     if args.ntargets is not None:
-        n_target = args.ntargets
+        n_targets = args.ntargets
 
     first_target = None
     if args.mintarget is not None:
         first_target = args.mintarget
-    elif n_target is not None:
+    elif n_targets is not None:
         first_target = 0
 
     # Multiprocessing processes to use if MPI is disabled.

--- a/py/redrock/plotspec.py
+++ b/py/redrock/plotspec.py
@@ -97,7 +97,7 @@ class PlotSpec(object):
 
         fulltype = zz['spectype']
         if zz['subtype'] != '':
-            fulltype = fulltype+":"+zz['subtype']
+            fulltype = fulltype+':::'+zz['subtype']
         tp = self.templates[fulltype]
 
         if tp.type != zz['spectype']:

--- a/py/redrock/plotspec.py
+++ b/py/redrock/plotspec.py
@@ -100,7 +100,7 @@ class PlotSpec(object):
             fulltype = fulltype+':::'+zz['subtype']
         tp = self.templates[fulltype]
 
-        if tp.type != zz['spectype']:
+        if tp.template_type != zz['spectype']:
             raise ValueError('spectype {} not in'
                 ' templates'.format(zz['spectype']))
 
@@ -169,7 +169,7 @@ class PlotSpec(object):
                 np.max(model)*1.05)
 
         #- Label object type and redshift
-        label = 'znum {} {} z={:.3f}'.format(self.znum, tp.fulltype, zz['z'])
+        label = 'znum {} {} z={:.3f}'.format(self.znum, tp.full_type, zz['z'])
         print('target {} id {} {}'.format(self.itarget, target.id, label))
         ytext = ymin+0.9*(ymax-ymin)
         self._ax2.text(3800, ytext, label)

--- a/py/redrock/targets.py
+++ b/py/redrock/targets.py
@@ -53,6 +53,7 @@ class Spectrum(object):
             self.R_data = mp_array(self.R.data)
             del self.R
 
+            self._csrshape = self.Rcsr.shape
             self.Rcsr_indices = mp_array(self.Rcsr.indices)
             self.Rcsr_indptr = mp_array(self.Rcsr.indptr)
             self.Rcsr_data = mp_array(self.Rcsr.data)
@@ -75,7 +76,8 @@ class Spectrum(object):
             del self.R_offsets
 
             self.Rcsr = scipy.sparse.csr_matrix((np.array(self.Rcsr_data),
-                np.array(self.Rcsr_indices), np.array(self.Rcsr_indptr)))
+                np.array(self.Rcsr_indices), np.array(self.Rcsr_indptr)),
+                shape=self._csrshape)
             del self.Rcsr_data
             del self.Rcsr_indices
             del self.Rcsr_indptr

--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -121,7 +121,7 @@ class Template(object):
         """Return formatted type:subtype string.
         """
         if self._subtype != '':
-            return '{}:{}'.format(self._rrtype, self._subtype)
+            return '{}:::{}'.format(self._rrtype, self._subtype)
         else:
             return self._rrtype
 
@@ -180,7 +180,7 @@ def find_templates(template_dir=None):
     if template_dir is None:
         raise IOError("ERROR: can't find template_dir, $RR_TEMPLATE_DIR, or {rrcode}/templates/")
 
-    return glob(os.path.join(template_dir, 'rrtemplate-*.fits'))
+    return sorted(glob(os.path.join(template_dir, 'rrtemplate-*.fits')))
 
 
 class DistTemplatePiece(object):

--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -81,7 +81,7 @@ class Template(object):
                         np.log10(1+4.0), 5e-4) - 1
                 else:
                     raise ValueError("Unknown redshift range to use for "
-                        "template type {}".format(rrtype))
+                        "template type {}".format(self._rrtype))
 
             self._subtype = None
             if 'RRSUBTYP' in hdr:

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -111,10 +111,8 @@ def zfind(targets, templates, mp_procs=1, nminima=3):
     # For each of our local targets, refine the redshift fit close to the
     # minima in the coarse fit.
 
-    #sort = np.array([ t.template.full_type for t in templates]).argsort()
-    #for t in np.array(list(templates))[sort]:
-    #print([ t.template.full_type for t in templates])
-    for t in templates:
+    sort = np.array([ t.template.full_type for t in templates]).argsort()
+    for t in np.array(list(templates))[sort]:
         ft = t.template.full_type
 
         if am_root:

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -111,6 +111,9 @@ def zfind(targets, templates, mp_procs=1, nminima=3):
     # For each of our local targets, refine the redshift fit close to the
     # minima in the coarse fit.
 
+    #sort = np.array([ t.template.full_type for t in templates]).argsort()
+    #for t in np.array(list(templates))[sort]:
+    #print([ t.template.full_type for t in templates])
     for t in templates:
         ft = t.template.full_type
 
@@ -207,8 +210,8 @@ def zfind(targets, templates, mp_procs=1, nminima=3):
                     continue
                 tmp = allresults[tid][fulltype]['zfit']
                 #- TODO: reconsider fragile parsing of fulltype
-                if fulltype.count(':') > 0:
-                    spectype, subtype = fulltype.split(':')
+                if fulltype.count(':::') > 0:
+                    spectype, subtype = fulltype.split(':::')
                 else:
                     spectype, subtype = (fulltype, '')
                 tmp['spectype'] = spectype


### PR DESCRIPTION
Allow to read SDSS templates from `http://www.sdss3.org/svn//repo/idlspec2d/trunk/templates/`.

`bin/rrconvertSDSStemplates -infile <SDSS_templates> --outpath <folder_where_to_save>` allow to transform the SDSS templates into a format readable by redrock. One file per template.

Change the formating `spectype:subtype` into `spectype:::subtype` for two reasons: some stellar templates have a `:` in their name, also `:` is hard to look for with grep since it is used for each loop or condition in Python.

Fixes issue https://github.com/desihub/redrock/issues/66
Fixes also issue https://github.com/desihub/redrock/issues/74
Fixes also issue https://github.com/desihub/redrock/issues/83
Fixes also issue https://github.com/desihub/redrock/issues/82
Fixes also issue https://github.com/desihub/redrock/issues/58