### PR TITLE
Add script to easily plot redrock

### DIFF
--- a/bin/rrplot
+++ b/bin/rrplot
@@ -4,52 +4,40 @@ import argparse
 import redrock
 from astropy.table import Table
 
-def plotboss():
+parser = argparse.ArgumentParser(description="Plot redrock results for"
+    " BOSS target spectra.")
 
-    parser = argparse.ArgumentParser(description="Plot redrock results for"
-        " BOSS target spectra.")
+parser.add_argument("--datatype", type=str, default='desi',
+    required=False, help="input data type: desi or boss")
 
-    parser.add_argument("--datatype", type=str, default='desi',
-        required=False, help="input data type: desi or boss")
+parser.add_argument("--data", type=str, default=None,
+    required=True, help="input data path")
 
-    parser.add_argument("--data", type=str, default=None,
-        required=True, help="input data path")
+parser.add_argument("-o", "--output", type=str, default=None,
+    required=True, help="output redrock h5 file")
 
-    parser.add_argument("-o", "--output", type=str, default=None,
-        required=True, help="output redrock h5 file")
+parser.add_argument("-t", "--templates", type=str, default=None,
+    required=False, help="template directory")
 
-    parser.add_argument("--zbest", type=str, default=None,
-        required=True, help="output zbest FITS file")
+args = parser.parse_args()
 
-    parser.add_argument("-t", "--templates", type=str, default=None,
-        required=False, help="template directory")
+#- Templates
+templates_path = redrock.templates.find_templates(args.templates)
+templates = {}
+for el in templates_path:
+    t = redrock.templates.Template(filename=el)
+    templates[t.full_type] = t
 
-    args = parser.parse_args()
+#- Data
+if args.datatype=='desi':
+    from redrock.external import desi
+    targets = desi.DistTargetsDESI(args.data)._my_data
+elif args.datatype=='boss':
+    from redrock.external import boss
+    targets, targetids = boss.read_spectra(args.data)
 
-    #- Templates
-    templates_path = redrock.templates.find_templates(args.templates)
-    templates = {}
-    for el in templates_path:
-        t = redrock.templates.Template(filename=el)
-        templates[t.full_type] = t
+#- Redrock
+zscan, zfit = redrock.results.read_zscan(args.output)
 
-    #- Data
-    if args.datatype=='desi':
-        #- Don't know yet how to do this
-        #from redrock.external import desi
-        #targets, targetids = boss.read_spectra(args.spplate)
-        print("Not yet implemented")
-    elif args.datatype=='boss':
-        from redrock.external import boss
-        targets, targetids = boss.read_spectra(args.data)
-
-    #- Redrock
-    zscan, zfit = redrock.results.read_zscan(args.output)
-    zbest = Table.read(args.zbest)
-
-    #- Plot
-    p = redrock.PlotSpec(targets, templates, zscan, zfit)
-
-    return
-
-plotboss()
+#- Plot
+p = redrock.PlotSpec(targets, templates, zscan, zfit)

--- a/bin/rrplot
+++ b/bin/rrplot
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import argparse
+import redrock
+from astropy.table import Table
+
+def plotboss():
+
+    parser = argparse.ArgumentParser(description="Plot redrock results for"
+        " BOSS target spectra.")
+
+    parser.add_argument("--datatype", type=str, default='desi',
+        required=False, help="input data type: desi or boss")
+
+    parser.add_argument("--data", type=str, default=None,
+        required=True, help="input data path")
+
+    parser.add_argument("-o", "--output", type=str, default=None,
+        required=True, help="output redrock h5 file")
+
+    parser.add_argument("--zbest", type=str, default=None,
+        required=True, help="output zbest FITS file")
+
+    parser.add_argument("-t", "--templates", type=str, default=None,
+        required=False, help="template directory")
+
+    args = parser.parse_args()
+
+    #- Templates
+    templates_path = redrock.templates.find_templates(args.templates)
+    templates = {}
+    for el in templates_path:
+        t = redrock.templates.Template(filename=el)
+        templates[t.full_type] = t
+
+    #- Data
+    if args.datatype=='desi':
+        #- Don't know yet how to do this
+        #from redrock.external import desi
+        #targets, targetids = boss.read_spectra(args.spplate)
+        print("Not yet implemented")
+    elif args.datatype=='boss':
+        from redrock.external import boss
+        targets, targetids = boss.read_spectra(args.data)
+
+    #- Redrock
+    zscan, zfit = redrock.results.read_zscan(args.output)
+    zbest = Table.read(args.zbest)
+
+    #- Plot
+    p = redrock.PlotSpec(targets, templates, zscan, zfit)
+
+    return
+
+plotboss()

--- a/bin/rrplot
+++ b/bin/rrplot
@@ -4,16 +4,16 @@ import argparse
 import redrock
 
 parser = argparse.ArgumentParser(description="Plot redrock results for"
-    " BOSS target spectra.")
+    " DESI or BOSS target spectra.")
 
 parser.add_argument("--datatype", type=str, default='desi',
     required=False, help="input data type: desi or boss")
 
-parser.add_argument("--data", type=str, default=None,
-    required=True, help="input data path")
+parser.add_argument("--specfile", type=str, default=None,
+    required=True, help="input spectra or spPlate file")
 
-parser.add_argument("-o", "--output", type=str, default=None,
-    required=True, help="output redrock h5 file")
+parser.add_argument("--rrfile", type=str, default=None,
+    required=True, help="redrock details h5 file from rrdesi/rrboss")
 
 parser.add_argument("-t", "--templates", type=str, default=None,
     required=False, help="template directory")
@@ -30,13 +30,13 @@ for el in templates_path:
 #- Data
 if args.datatype=='desi':
     from redrock.external import desi
-    targets = desi.DistTargetsDESI(args.data)._my_data
+    targets = desi.DistTargetsDESI(args.specfile)._my_data
 elif args.datatype=='boss':
     from redrock.external import boss
-    targets, targetids = boss.read_spectra(args.data)
+    targets, targetids = boss.read_spectra(args.specfile)
 
 #- Redrock
-zscan, zfit = redrock.results.read_zscan(args.output)
+zscan, zfit = redrock.results.read_zscan(args.rrfile)
 
 #- Plot
 p = redrock.PlotSpec(targets, templates, zscan, zfit)

--- a/bin/rrplot
+++ b/bin/rrplot
@@ -2,7 +2,6 @@
 
 import argparse
 import redrock
-from astropy.table import Table
 
 parser = argparse.ArgumentParser(description="Plot redrock results for"
     " BOSS target spectra.")

--- a/py/redrock/_zscan.py
+++ b/py/redrock/_zscan.py
@@ -27,6 +27,7 @@ def _zchi2_one(Tb, weights, flux, wflux, zcoeff):
 
     M = Tb.T.dot(np.multiply(weights[:,None], Tb))
     y = Tb.T.dot(wflux)
+    
     zcoeff[:] = np.linalg.solve(M, y)
 
     model = Tb.dot(zcoeff)

--- a/py/redrock/plotspec.py
+++ b/py/redrock/plotspec.py
@@ -27,9 +27,9 @@ class PlotSpec(object):
         self.znum = 0
         self.smooth = 1
         self.truth = truth
-        self.tagetid_to_itarget = {}
+        self.targetid_to_itarget = {}
         for i, t in enumerate(self.targets):
-            self.tagetid_to_itarget[t.id] = i
+            self.targetid_to_itarget[t.id] = i
 
         self._fig = plt.figure()
         self._ax1 = self._fig.add_subplot(211)

--- a/py/redrock/plotspec.py
+++ b/py/redrock/plotspec.py
@@ -53,7 +53,7 @@ class PlotSpec(object):
 
         plt.ion()
         self.plot()
-        plt.show()
+        plt.show(block=True)
 
     def _onkeypress(self, event):
         ### print('key', event.key)

--- a/py/redrock/plotspec.py
+++ b/py/redrock/plotspec.py
@@ -27,6 +27,9 @@ class PlotSpec(object):
         self.znum = 0
         self.smooth = 1
         self.truth = truth
+        self.tagetid_to_itarget = {}
+        for i, t in enumerate(self.targets):
+            self.tagetid_to_itarget[t.id] = i
 
         self._fig = plt.figure()
         self._ax1 = self._fig.add_subplot(211)
@@ -53,7 +56,7 @@ class PlotSpec(object):
 
         plt.ion()
         self.plot()
-        plt.show(block=True)
+        plt.show()
 
     def _onkeypress(self, event):
         ### print('key', event.key)


### PR DESCRIPTION
Here is a script `bin/rrplot` that can be run inside a `ipython --pylab` to plot redrock results.
It allows to transform from a multiple line command (like in tutorial) to a one line command.
Works both with `desi` or `boss`
example:
```
ipython --pylab
%run <path_to_rrplot> --datatype boss --data <path_to_spPlate> -o <path_to_h5_file>
```