### PR TITLE
add seed to rrstartemplate

### DIFF
--- a/bin/rrgaltemplate
+++ b/bin/rrgaltemplate
@@ -91,6 +91,6 @@ hdus = fits.HDUList()
 hdus.append(fits.PrimaryHDU(model.eigvec, header=header))
 hdus.append(fits.ImageHDU(model.coeff, name='ARCHETYPE_COEFF'))
 
-hdus.writeto(opts.outfile, clobber=True)
+hdus.writeto(opts.outfile, overwrite=True)
 print('RR: Wrote '+opts.outfile)
 

--- a/bin/rrgaltemplate
+++ b/bin/rrgaltemplate
@@ -28,6 +28,7 @@ parser = optparse.OptionParser(usage = "%prog [options]")
 parser.add_option("-o", "--outfile", type=str,  help="Output filename")
 parser.add_option("--niter", type=int,  help="Number of EMPCA iterations to run [%default]", default=10)
 parser.add_option("--nvec", type=int,  help="Number of basis vectors to generate [%default]", default=10)
+parser.add_option("--seed", type=int,  help="Seed for desisim.templates.ELG and LRG [%default]", default=123456)
 
 opts, args = parser.parse_args()
 
@@ -44,12 +45,12 @@ dw = 0.1
 wave = np.arange(3500/(1+1.85), 11000+dw/2, dw)
 nelg = 1000
 nlrg = 500
-tflux, twave, tmeta = ELG().make_templates(nelg, restframe=True, nocolorcuts=True)
+tflux, twave, tmeta = ELG().make_templates(nelg, restframe=True, nocolorcuts=True,seed=opts.seed)
 elgflux = np.zeros((nelg, len(wave)))
 for i in range(nelg):
     elgflux[i] = resample_flux(wave, twave, tflux[i])
 
-tflux, twave, tmeta = LRG().make_templates(nlrg, restframe=True, nocolorcuts=True)
+tflux, twave, tmeta = LRG().make_templates(nlrg, restframe=True, nocolorcuts=True,seed=opts.seed+nelg)
 lrgflux = np.zeros((nlrg, len(wave)))
 for i in range(nlrg):
     lrgflux[i] = resample_flux(wave, twave, tflux[i])
@@ -83,6 +84,7 @@ header['RRSUBTYP'] = ''
 # header['RRINPUT'] = opts.infile
 header['RRVER'] = redrock.__version__
 header['INSPEC'] = os.environ['DESI_BASIS_TEMPLATES']
+header['SEED'] = opts.seed
 header['EXTNAME'] = 'BASIS_VECTORS'
 
 hdus = fits.HDUList()

--- a/bin/rrstartemplate
+++ b/bin/rrstartemplate
@@ -28,6 +28,7 @@ parser = optparse.OptionParser(usage = "%prog [options]")
 parser.add_option("-o", "--outfile", type=str,  help="Output filename")
 parser.add_option("--niter", type=int,  help="Number of EMPCA iterations to run [%default]", default=5)
 parser.add_option("--nvec", type=int,  help="Number of basis vectors to generate [%default]", default=5)
+parser.add_option("--seed", type=int,  help="Seed for desisim.templates.STAR [%default]", default=12345)
 
 opts, args = parser.parse_args()
 
@@ -41,7 +42,7 @@ if opts.outfile is None:
 dw = 0.1
 wave = np.arange(3000, 11000+dw/2, dw)
 nstar = 1000
-tflux, twave, meta = STAR().make_templates(nstar, restframe=True)
+tflux, twave, meta = STAR().make_templates(nstar, restframe=True,seed=opts.seed)
 flux = np.zeros((nstar, len(wave)))
 for i in range(nstar):
     flux[i] = resample_flux(wave, twave, tflux[i])
@@ -65,7 +66,8 @@ outbase, outext = os.path.splitext(opts.outfile)
 mx = dict()
 for spectype, (mintemp, maxtemp) in typetemp.items():
     ii = (mintemp <= meta['TEFF']) & (meta['TEFF'] <= maxtemp)
-    
+    print('RR: Using {} spectra to get the templates'.format(ii.sum()))
+
     #- EMPCA fit
     print('RR: Fitting basis vectors for spectral type {} with {} templates'.format(spectype, np.count_nonzero(ii)))
     mx[spectype] = model = empca(flux[ii], niter=opts.niter, nvec=opts.nvec)
@@ -93,6 +95,6 @@ for spectype, (mintemp, maxtemp) in typetemp.items():
     hdus.append(fits.ImageHDU(model.coeff, name='ARCHETYPE_COEFF'))
 
     outfile = outbase + '-' + spectype + outext
-    hdus.writeto(outfile, clobber=True)
+    hdus.writeto(outfile, overwrite=True)
     print('RR: Wrote '+outfile)
 

--- a/bin/rrstartemplate
+++ b/bin/rrstartemplate
@@ -41,7 +41,7 @@ if opts.outfile is None:
 #- Generate templates and resample to 0.1A grid
 dw = 0.1
 wave = np.arange(3000, 11000+dw/2, dw)
-nstar = 1000
+nstar = 10000
 tflux, twave, meta = STAR().make_templates(nstar, restframe=True,seed=opts.seed)
 flux = np.zeros((nstar, len(wave)))
 for i in range(nstar):
@@ -88,6 +88,7 @@ for spectype, (mintemp, maxtemp) in typetemp.items():
     # header['RRINPUT'] = opts.infile
     header['RRVER'] = redrock.__version__
     header['INSPEC'] = os.environ['DESI_BASIS_TEMPLATES']
+    header['SEED'] = opts.seed
     header['EXTNAME'] = 'BASIS_VECTORS'
 
     hdus = fits.HDUList()


### PR DESCRIPTION
This PR adds setting the seed to the desisim.templates.STAR production.
This is important to be able to reproduce the templates.
Should we put the seed inside the fits file header?
Do you want me to add this to the other template generation (i.e. for galaxy)?
Also the current code produces only 1000 spectra.
This means that only around 150 spectra are used for the definition of each templates.
We could change the code to have 1000 for each class.