### PR TITLE
set ivar=0 for pixels where integral of resolution is less than 0.99

### DIFF
--- a/py/redrock/constants.py
+++ b/py/redrock/constants.py
@@ -5,3 +5,4 @@ redrock.constants
 Set constants used by the rest of the package.
 """
 max_velo_diff = 1000.0  # km/s
+min_resolution_integral = 0.99

--- a/py/redrock/targets.py
+++ b/py/redrock/targets.py
@@ -14,6 +14,7 @@ from astropy.table import Table
 
 from .utils import mp_array, distribute_work
 
+from . import constants
 
 class Spectrum(object):
     """Simple container class for an individual spectrum.
@@ -28,6 +29,9 @@ class Spectrum(object):
 
     """
     def __init__(self, wave, flux, ivar, R, Rcsr):
+        if R is not None:
+            w = np.asarray(R.sum(axis=1))[:,0]<constants.min_resolution_integral
+            ivar[w] = 0.
         self.nwave = wave.size
         self.wave = wave
         self.flux = flux


### PR DESCRIPTION
fix issue https://github.com/desihub/redrock/issues/92 by masking pixels with the integral of the resolution less than 0.99, i.e. the first two and the last two.