### PR TITLE
Improve spectra reading speed

### DIFF
--- a/py/redrock/targets.py
+++ b/py/redrock/targets.py
@@ -127,7 +127,7 @@ class Target(object):
             self.compute_coadd()
 
     ### @profile
-    def compute_coadd(self, cache_Rcsr):
+    def compute_coadd(self, cache_Rcsr=False):
         """Compute the coadd from the current spectra list.
 
         Args:


### PR DESCRIPTION
This PR significantly improves the speed of reading spectra files by `DistTargetsDESI`.  The largest improvements were from:
* faster coadd by stacking resolution matrix diagonals and then creating a single `scipy.sparse.dia_matrix` instead of creating and stacking multiple `dia_matrix` objects.
* Only pre-create the CSR sparse format cache upon request (needed for fast running of redrock, but not for loading spectra with redrock, e.g. for visualization).

Testing on a file with 4134 exposures of 1694 targets, the read time went from 1m 27s to 15.5s.  I also verified that the Rcsr caching change didn't change the overall runtime of rrdesi for both MPI and multiprocessing versions.