### PR TITLE
module env workaround for hdf5 file locking bug

### DIFF
--- a/etc/redrock.module
+++ b/etc/redrock.module
@@ -81,3 +81,4 @@ setenv [string toupper $product] $PRODUCT_DIR
 setenv KMP_AFFINITY disabled
 setenv MPICH_GNI_FORK_MODE FULLCOPY
 setenv OMP_NUM_THREADS 1
+setenv HDF5_USE_FILE_LOCKING FALSE


### PR DESCRIPTION
This PR sets $HDF5_USE_FILE_LOCKING=FALSE in the redrock modules file to work around a bug in HDF5 1.9 that prevents writing redrock output to /project or /home without setting this.

I'm tempted to throw hdf5 overboard anyway, but this is a minimal fix in the meantime.