### PR TITLE
fix issue of Lya transmission in mpi

### DIFF
--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -300,12 +300,12 @@ class DistTemplate(object):
             for z in myz:
                 data.append(results[z])
 
-            # Correct spectra for Lyman-series
-            for i, z in enumerate(myz):
-                for k in list(self._dwave.keys()):
-                    T = transmission_Lyman(z,self._dwave[k])
-                    for vect in range(data[i][k].shape[1]):
-                        data[i][k][:,vect] *= T
+        # Correct spectra for Lyman-series
+        for i, z in enumerate(myz):
+            for k in list(self._dwave.keys()):
+                T = transmission_Lyman(z,self._dwave[k])
+                for vect in range(data[i][k].shape[1]):
+                    data[i][k][:,vect] *= T
 
         self._piece = DistTemplatePiece(self._comm_rank, myz, data)
 


### PR DESCRIPTION
Fix issue https://github.com/desihub/redrock/issues/115 where the Lyman-alpha transmission was not applied when running mpi.
However I don't know enough mpi to know if we could fix this in a more computing time efficient way.
Tested and works on:
```
srun -A desi -t 30:00 -C haswell --qos interactive -N 1 -n 32 -c 2
rrdesi_mpi /global/cscratch1/sd/sjbailey/desi/dev/end2end/spectro/redux/mini/spectra-64/52/5263/spectra-64-5263.fits
--output redrock-64-5263__mpi_test.h5
--zbest zbest-64-5263__mpi_test.h5
--targetids 288230398226337452,288230398226337460,288230398226337464
```