### PR TITLE
add version number when creating templates

### DIFF
--- a/bin/rrconvertSDSStemplates
+++ b/bin/rrconvertSDSStemplates
@@ -12,6 +12,7 @@ def convert():
     parser = optparse.OptionParser(usage = "%prog [options]")
     parser.add_option("-i", "--infile", type="string", help="input SDSS templates")
     parser.add_option("-o", "--outfolder", type="string", help="output folder")
+    parser.add_option('--version', type=str, help='Template version')
     opts, args = parser.parse_args()
 
     ###
@@ -59,8 +60,8 @@ def convert():
         rx = re.search('\((\d+)\)$', subtype)
         if rx:
             header['INDOUSID'] = (int(rx.groups()[0]), 'Indo-US stellar template ID')
-
         header['RRVER']    = redrock.__version__
+        header['VERSION'] = (opts.version, 'Template version')
         header['INSPEC']   = opts.infile
         header['EXTNAME']  = "BASIS_VECTORS"
         header.add_comment('Converted from SDSS template format')

--- a/bin/rrgaltemplate
+++ b/bin/rrgaltemplate
@@ -29,6 +29,7 @@ parser.add_option("-o", "--outfile", type=str,  help="Output filename")
 parser.add_option("--niter", type=int,  help="Number of EMPCA iterations to run [%default]", default=10)
 parser.add_option("--nvec", type=int,  help="Number of basis vectors to generate [%default]", default=10)
 parser.add_option("--seed", type=int,  help="Seed for desisim.templates.ELG and LRG [%default]", default=123456)
+parser.add_option('--version', type=str, help='Template version')
 
 opts, args = parser.parse_args()
 
@@ -83,6 +84,7 @@ header['RRTYPE']   = 'GALAXY'
 header['RRSUBTYP'] = ''
 # header['RRINPUT'] = opts.infile
 header['RRVER'] = redrock.__version__
+header['VERSION'] = (opts.version, 'Template version')
 header['INSPEC'] = os.environ['DESI_BASIS_TEMPLATES']
 header['SEED'] = opts.seed
 header['EXTNAME'] = 'BASIS_VECTORS'

--- a/bin/rrqsotemplate
+++ b/bin/rrqsotemplate
@@ -19,6 +19,7 @@ from desispec.interpolation import resample_flux
 parser = optparse.OptionParser(usage = "%prog [options]")
 parser.add_option("-i", "--infile", type="string",  help="input BOSS QSO eigenspectra")
 parser.add_option("-o", "--outfile", type="string",  help="output filename")
+parser.add_option('--version', type=str, help='Template version')
 
 opts, args = parser.parse_args()
 
@@ -35,6 +36,7 @@ header['RRTYPE']   = 'QSO'
 header['RRSUBTYP'] = ''
 # header['RRINPUT'] = opts.infile
 header['RRVER'] = redrock.__version__
+header['VERSION'] = (opts.version, 'Template version')
 header['INSPEC'] = opts.infile
 header['EXTNAME'] = 'BASIS_VECTORS'
 

--- a/bin/rrstartemplate
+++ b/bin/rrstartemplate
@@ -29,6 +29,7 @@ parser.add_option("-o", "--outfile", type=str,  help="Output filename")
 parser.add_option("--niter", type=int,  help="Number of EMPCA iterations to run [%default]", default=5)
 parser.add_option("--nvec", type=int,  help="Number of basis vectors to generate [%default]", default=5)
 parser.add_option("--seed", type=int,  help="Seed for desisim.templates.STAR [%default]", default=12345)
+parser.add_option('--version', type=str, help='Template version')
 
 opts, args = parser.parse_args()
 
@@ -87,6 +88,7 @@ for spectype, (mintemp, maxtemp) in typetemp.items():
     header['RRSUBTYP'] = spectype
     # header['RRINPUT'] = opts.infile
     header['RRVER'] = redrock.__version__
+    header['VERSION'] = (opts.version, 'Template version')
     header['INSPEC'] = os.environ['DESI_BASIS_TEMPLATES']
     header['SEED'] = opts.seed
     header['EXTNAME'] = 'BASIS_VECTORS'

--- a/bin/rrstarwdtemplate
+++ b/bin/rrstarwdtemplate
@@ -29,6 +29,7 @@ parser.add_option("-o", "--outfile", type=str,  help="Output filename")
 parser.add_option("--niter", type=int,  help="Number of EMPCA iterations to run [%default]", default=5)
 parser.add_option("--nvec", type=int,  help="Number of basis vectors to generate [%default]", default=5)
 parser.add_option("--seed", type=int, help="Seed for WD(subtype='..').make_templates [%default]", default=1234567)
+parser.add_option('--version', type=str, help='Template version')
 
 opts, args = parser.parse_args()
 
@@ -79,6 +80,7 @@ header['CDELT1'] = dw
 header['RRTYPE']   = 'STAR'
 header['RRSUBTYP'] = 'WD'
 header['RRVER'] = redrock.__version__
+header['VERSION'] = (opts.version, 'Template version')
 header['INSPEC'] = os.environ['DESI_BASIS_TEMPLATES']
 header['SEED'] = opts.seed
 header['EXTNAME'] = 'BASIS_VECTORS'


### PR DESCRIPTION
add version number when creating templates.
Maybe these different scripts to create template PCA dshould be in `redrock-templates/bin/`.
What do you think @sbailey?

Step in fixing https://github.com/desihub/redrock/issues/25