### PR TITLE
Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ addons:
             # - libboost-all-dev
             # - libcfitsio3-dev
 # python:
-    # - 2.6
+    # - 2.6 NOTE: no longer testing python 2.x
     # - 2.7
     # - 3.3
     # - 3.4
@@ -54,10 +54,10 @@ env:
         # to repeat them for all configurations.
         # - NUMPY_VERSION=1.10
         # - SCIPY_VERSION=0.16
-        - ASTROPY_VERSION=1.3
-        - SPHINX_VERSION=1.5
+        - ASTROPY_VERSION=2.0.7
+        # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=1.9.9
-        # - SPECLITE_VERSION=0.5
+        # - SPECLITE_VERSION=0.7
         # - SPECTER_VERSION=0.8.1
         # - DESIMODEL_VERSION=0.7.0
         # - DESIMODEL_DATA=branches/test-0.7.0
@@ -85,10 +85,12 @@ env:
         # Debug the Travis install process.
         - DEBUG=False
     matrix:
-        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=2.7 SETUP_CMD='bdist_egg'
+        # - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
+        # - PYTHON_VERSION=2.7 SETUP_CMD='bdist_egg'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='bdist_egg'
+        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.6 SETUP_CMD='bdist_egg'
 
 matrix:
     # Don't wait for allowed failures.
@@ -97,10 +99,17 @@ matrix:
     # OS X support is still experimental, so don't penalize failuures.
     allow_failures:
         - os: osx
+        - os: linux
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
+               ASTROPY_VERSION=3.0
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+               PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
     include:
 
         # Check for sphinx doc build warnings.
+        # Note: this test is not a perfectly realistic test of ReadTheDocs
+        # builds, which operate in a much more bare-bones environment
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx --warning-is-error'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
@@ -115,13 +124,25 @@ matrix:
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
         # Standard tests.
+        # - os: linux
+        #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'
+        #        CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+        #        PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
+
+        # Redundant with the coverage test
+        # - os: linux
+        #   env: PYTHON_VERSION=3.5 SETUP_CMD='test'
+        #        CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+        #        PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
+
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
         - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='test'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
+               ASTROPY_VERSION=3.0
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -11,16 +11,28 @@ This is used to include docstrings from modules. See `the autodoc documentation`
 If you're loading a module here, and don't see some functions, try adding the
 ``:imported-members:`` option.
 
+.. pro tip: if you keep these in alphabetical order, it will be much
+   easier to ensure all the modules are present.
+
 .. automodule:: redrock
     :members:
 
 .. automodule:: redrock.constants
     :members:
 
-.. automodule:: redrock.utils
+.. automodule:: redrock.external
     :members:
 
-.. automodule:: redrock.zwarning
+.. automodule:: redrock.external.boss
+    :members:
+
+.. automodule:: redrock.external.desi
+    :members:
+
+.. automodule:: redrock.fitz
+    :members:
+
+.. automodule:: redrock.plotspec
     :members:
 
 .. automodule:: redrock.rebin
@@ -35,10 +47,7 @@ If you're loading a module here, and don't see some functions, try adding the
 .. automodule:: redrock.templates
     :members:
 
-.. automodule:: redrock.fitz
-    :members:
-
-.. automodule:: redrock.plotspec
+.. automodule:: redrock.utils
     :members:
 
 .. automodule:: redrock.zfind
@@ -47,11 +56,5 @@ If you're loading a module here, and don't see some functions, try adding the
 .. automodule:: redrock.zscan
     :members:
 
-.. automodule:: redrock.external
-    :members:
-
-.. automodule:: redrock.external.boss
-    :members:
-
-.. automodule:: redrock.external.desi
+.. automodule:: redrock.zwarning
     :members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,11 +11,12 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import os
 import os.path
-
+from importlib import import_module
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -45,7 +46,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    napoleon_extension
+    'sphinx.ext.napoleon'
 ]
 
 # Configuration for intersphinx, copied from astropy.
@@ -131,10 +132,13 @@ napoleon_include_private_with_doc = True
 # This value contains a list of modules to be mocked up. This is useful when
 # some external dependencies are not met at build time and break the
 # building process.
-autodoc_mock_imports = ['astropy', 'astropy.io', 'astropy.table',
-                        'desispec', 'desispec.io', 'desispec.resolution',
-                        'fitsio', 'numba', 'numpy',
-                        'scipy.constants', 'scipy.sparse']
+autodoc_mock_imports = []
+for missing in ('astropy', 'desispec', 'desiutil', 'fitsio', 'numba',
+                'numpy', 'scipy'):
+    try:
+        foo = import_module(missing)
+    except ImportError:
+        autodoc_mock_imports.append(missing)
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
This PR fixes #125 by moving tests to Astropy 2.  There are also updates to the Sphinx configuration, and Python 2 tests are dropped.