### PR TITLE
update deltachi2 calc to not consider nearby redshifts

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ redrock Change Log
 0.12.1 (unreleased)
 -------------------
 
-* No changes yet.
+* update DELTACHI2 column definition to match how it is used in ZWARN flag,
+  i.e. excluding other candidates with nearby redshifts.
 
 0.12.0 (2018-07-18)
 -------------------

--- a/py/redrock/test/test_zscan.py
+++ b/py/redrock/test/test_zscan.py
@@ -8,7 +8,7 @@ from ..targets import DistTargetsCopy
 from ..templates import DistTemplate
 from ..rebin import rebin_template
 from ..zscan import calc_zchi2_one, calc_zchi2_targets, spectral_data
-from ..zfind import zfind
+from ..zfind import zfind, calc_deltachi2
 
 from . import util
 
@@ -64,6 +64,15 @@ class TestZScan(unittest.TestCase):
         self.assertLess(zx1['zerr'], 0.002)
         self.assertLess(zx2['zerr'], 0.002)
 
+    def test_calc_deltachi2(self):
+        chi2 = np.array([1.0, 2.0, 4.0, 8.0])
+        z = np.array([3.0, 3.1, 3.2, 3.3])
+        dchi2 = calc_deltachi2(chi2, z)
+        self.assertTrue(np.all(dchi2 == np.array([1, 2, 4, 0.0])), dchi2)
+
+        z = np.array([3.0, 3.0, 4.0, 4.0])
+        dchi2 = calc_deltachi2(chi2, z)
+        self.assertTrue(np.all(dchi2 == np.array([3, 2, 0.0, 0.0])), dchi2)
 
     def test_parallel_zscan(self):
         z1 = 0.2


### PR DESCRIPTION
This PR updates the DELTACHI2 column definition to match how it is used by the ZWARN SMALL_DELTA_CHI2 flag, i.e. excluding other candidate redshifts within 1000 km/s.  Previously DELTACHI2 was the raw delta(chi2), while the ZWARN flag was set based upon a combination of the raw delta(chi2) and the redshift differences, leading to confusion about cases where DELTACHI2 < SMALL_DELTACHI2_LIMIT but ZWARN=0.  This update makes it simpler for post-processing analyses to alter the DELTACHI2 threshold to tradeoff purity vs. efficiency.

Also see #133
