### PR TITLE
smaller z for galaxies

### DIFF
--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -74,7 +74,7 @@ class Template(object):
                 if self._rrtype == 'GALAXY':
                     # redshifts = 10**np.arange(np.log10(1+0.005),
                     # np.log10(1+2.0), 1.5e-4) - 1
-                    self._redshifts = 10**np.arange(np.log10(1+0.005),
+                    self._redshifts = 10**np.arange(np.log10(1-0.005),
                         np.log10(1+1.7), 3e-4) - 1
                 elif self._rrtype == 'STAR':
                     self._redshifts = np.arange(-0.002, 0.00201, 4e-5)


### PR DESCRIPTION
This PR solves https://github.com/desihub/redrock/issues/135, by going down to `z=-0.005` for galaxies.
This allows to recover the proper redshift for BGS with very low z. However, there is then a confusion between `STAR` and `GALAXY` `SPECTYPE`.