### PR TITLE
Read multiple spplates

### DIFF
--- a/bin/rrplot
+++ b/bin/rrplot
@@ -13,7 +13,7 @@ parser.add_argument("--datatype", type=str, default='desi',
     required=False, help="input data type: desi or boss")
 
 parser.add_argument("--specfile", type=str, default=None,
-    required=True, help="input spectra or spPlate file")
+    required=True, help="input spectra or spPlate files", nargs='*')
 
 parser.add_argument("--targetids", type=str, default=None,
     required=False, help="comma-separated list of target IDs")
@@ -53,7 +53,7 @@ else:
 #- Data
 if args.datatype=='desi':
     from redrock.external import desi
-    targets = desi.DistTargetsDESI(args.specfile, targetids=targetids)._my_data
+    targets = desi.DistTargetsDESI(args.specfile[0], targetids=targetids)._my_data
 elif args.datatype=='boss':
     from redrock.external import boss
     targets, targetids = boss.read_spectra(args.specfile, targetids=targetids)


### PR DESCRIPTION
This PR adds reading multiple observations of the same plate.
This allows to study the evolution of the redshift failure with the number of pass.
Since the mapping for each observation between fibers and object is different,
when two spplates are given, the code uses `TARGETID=THING_ID` from the `photoPlate` file,
instead of `TARGETID=PLATE*1000000000 + MJD*10000 + FIBERID`
This works for all science observation, not for SKY fibers.