### PR TITLE
sort targetids

### DIFF
--- a/py/redrock/external/boss.py
+++ b/py/redrock/external/boss.py
@@ -243,6 +243,8 @@ def read_spectra(spplates_name, targetids=None, use_frames=False,
 
     if targetids == None:
         targetids = sorted(list(dic_spectra.keys()))
+    else:
+        targetids = sorted(targetids)
 
     targets = []
     for targetid in targetids:

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -153,9 +153,10 @@ class DistTargetsDESI(DistTargets):
             # Now every process has the fibermap and number of HDUs.  Build the
             # mapping between spectral rows and target IDs.
 
-            keep_targetids = targetids
             if targetids is None:
-                keep_targetids = fmap["TARGETID"]
+                keep_targetids = sorted(fmap["TARGETID"])
+            else:
+                keep_targetids = sorted(targetids)
 
             # Select a subset of the target range from each file if desired.
 

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -247,9 +247,10 @@ def calc_zchi2_targets(targets, templates, mp_procs=1):
 
                 # Save the results into a dict keyed on the redshift chunk index
                 # for easy sorting at the end.
-                zchi2[t.local.index] = tzchi2
-                zcoeff[t.local.index] = tzcoeff
-                penalty[t.local.index] = tpenalty
+                for i in range(len(targets.local_target_ids())):
+                    zchi2[targets.local_target_ids()[i]] = tzchi2[i]
+                    zcoeff[targets.local_target_ids()[i]] = tzcoeff[i]
+                    penalty[targets.local_target_ids()[i]] = tpenalty[i]
 
                 prg = int(100.0 * prog * mpi_prog_frac)
                 if prg >= proglast + prog_chunk:
@@ -262,16 +263,6 @@ def calc_zchi2_targets(targets, templates, mp_procs=1):
 
                 # Cycle through the redshift slices
                 done = t.cycle()
-
-            # Concatenate the results, so that we end up with data for all
-            # redshifts for our local targets.
-
-            zchi2 = np.concatenate([ zchi2[p] for p in sorted(zchi2.keys()) ],
-                axis=1)
-            zcoeff = np.concatenate([ zcoeff[p] for p in sorted(zcoeff.keys()) ],
-                axis=1)
-            penalty = np.concatenate([ penalty[p] for p in \
-                sorted(penalty.keys()) ], axis=1)
 
         else:
             # Multiprocessing case.

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -326,27 +326,18 @@ def calc_zchi2_targets(targets, templates, mp_procs=1):
                 if len(mpdist[i]) == 0:
                     continue
                 res = qout.get()
-                zchi2[res[0]] = res[1]
-                zcoeff[res[0]] = res[2]
-                penalty[res[0]] = res[3]
-
-            # Concatenate the results, so that we end up with data for all
-            # redshifts for all targets.
-
-            zchi2 = np.concatenate([ zchi2[p] for p in sorted(zchi2.keys()) ],
-                axis=0)
-            zcoeff = np.concatenate([ zcoeff[p] for p in \
-                sorted(zcoeff.keys()) ], axis=0)
-            penalty = np.concatenate([ penalty[p] for p in \
-                sorted(penalty.keys()) ], axis=0)
+                for j in range(len(mpdist[i])):
+                    zchi2[mpdist[res[0]][j]] = res[1][j]
+                    zcoeff[mpdist[res[0]][j]] = res[2][j]
+                    penalty[mpdist[res[0]][j]] = res[3][j]
 
         stop = elapsed(start, "    Finished in", comm=t.comm)
 
-        for i, tg in enumerate(targets.local()):
-            results[tg.id][ft] = dict()
-            results[tg.id][ft]['redshifts'] = t.template.redshifts
-            results[tg.id][ft]['zchi2'] = zchi2[i]
-            results[tg.id][ft]['penalty'] = penalty[i]
-            results[tg.id][ft]['zcoeff'] = zcoeff[i]
+        for tid in sorted(zchi2.keys()):
+            results[tid][ft] = dict()
+            results[tid][ft]['redshifts'] = t.template.redshifts
+            results[tid][ft]['zchi2'] = zchi2[tid]
+            results[tid][ft]['penalty'] = penalty[tid]
+            results[tid][ft]['zcoeff'] = zcoeff[tid]
 
     return results

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -245,8 +245,7 @@ def calc_zchi2_targets(targets, templates, mp_procs=1):
                 tzchi2, tzcoeff, tpenalty = \
                     calc_zchi2(targets.local_target_ids(), targets.local(), t)
 
-                # Save the results into a dict keyed on the redshift chunk index
-                # for easy sorting at the end.
+                # Save the results into a dict keyed on targetid
                 for i in range(len(targets.local_target_ids())):
                     zchi2[targets.local_target_ids()[i]] = tzchi2[i]
                     zcoeff[targets.local_target_ids()[i]] = tzcoeff[i]


### PR DESCRIPTION
Fix issue https://github.com/desihub/redrock/issues/138, by sorting targetids.
However, this doesn't fix the reason why `zfind.py::zfind()` can mix information in the first place.
Tested on rrboss and on desi-minitest.