### PR TITLE
Use photoPosPlate instead of photoPlate

### DIFF
--- a/py/redrock/external/boss.py
+++ b/py/redrock/external/boss.py
@@ -116,7 +116,7 @@ def read_spectra(spplates_name, targetids=None, use_frames=False,
         mjd += [spplate[0].read_header()["MJD"]]
 
         if useThingid:
-            photoPlate = fitsio.FITS(spplate_name.replace('spPlate','photoPlate'))
+            photoPlate = fitsio.FITS(spplate_name.replace('spPlate','photoPosPlate'))
 
         if use_frames:
             path = os.path.dirname(spplate_name)


### PR DESCRIPTION
Use photoPosPlate instead of photoPlate.
photoPosPlate is a match between THING_ID and FIBERID using the position on the plate.
This is more stable than photoPlate, using the flux.