### PR TITLE
allow to read files if path with variable

### DIFF
--- a/py/redrock/results.py
+++ b/py/redrock/results.py
@@ -99,7 +99,7 @@ def read_zscan(filename):
     """
     import h5py
     # zbest = Table.read(filename, format='hdf5', path='zbest')
-    with h5py.File(filename, mode='r') as fx:
+    with h5py.File(os.path.expandvars(filename), mode='r') as fx:
         targetids = fx['targetids'].value
         spectypes = list(fx['zscan'].keys())
 


### PR DESCRIPTION
Allow to read files if path with variable.
Example in `ipython --pylab`:
```
run ~/Programs/desi/code/redrock/bin/rrplot
--datatype boss
--rrfile '$DESI_WORK/rrboss/SDSS_redrock_archetypes_newDeltaChi2/spplates/7612/rrdetail-7612-56972.h5'
--specfile '$BOSS_SPECTRO_REDUX/v5_10_10/7612/spPlate-7612-56972.fits'
--use-archetype
```