### PR TITLE
correct R norm bug

### DIFF
--- a/py/redrock/targets.py
+++ b/py/redrock/targets.py
@@ -31,8 +31,7 @@ class Spectrum(object):
     # @profile
     def __init__(self, wave, flux, ivar, R, Rcsr=None):
         if R is not None:
-            # w = np.asarray(R.sum(axis=1))[:,0]<constants.min_resolution_integral
-            w = np.asarray(R.data.sum(axis=0))<constants.min_resolution_integral
+            w = np.asarray(R.sum(axis=1))[:,0]<constants.min_resolution_integral
             ivar[w] = 0.
         self.nwave = wave.size
         self.wave = wave


### PR DESCRIPTION
This PR fixes a bug in the resolution matrix normalization cut.  Hélion had the correct code in PR #94 and I broke it while making the spectra reading faster in PR #114 .  This PR restores it to the original cut that Hélion had.  For background on this cut, see issue #92.