### PR TITLE
Fix bug dictionnary results

### DIFF
--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -316,7 +316,7 @@ def calc_zchi2_targets(targets, templates, mp_procs=1):
                 if len(mpdist[i]) == 0:
                     continue
                 res = qout.get()
-                for j in range(len(mpdist[i])):
+                for j in range(len(mpdist[res[0]])):
                     zchi2[mpdist[res[0]][j]] = res[1][j]
                     zcoeff[mpdist[res[0]][j]] = res[2][j]
                     penalty[mpdist[res[0]][j]] = res[3][j]

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -247,8 +247,7 @@ def calc_zchi2_targets(targets, templates, mp_procs=1):
 
                 # Save the results into a dict keyed on targetid
                 tids = targets.local_target_ids()
-                for i in range(len(tids)):
-                    tid = tids[i]
+                for i, tid in enumerate(tids):
                     if tid not in zchi2:
                         zchi2[tid] = {}
                         zcoeff[tid] = {}
@@ -324,8 +323,7 @@ def calc_zchi2_targets(targets, templates, mp_procs=1):
             for _ in range(len(procs)):
                 res = qout.get()
                 tids = mpdist[res[0]]
-                for j in range(len(tids)):
-                    tid = tids[j]
+                for j,tid in enumerate(tids):
                     zchi2[tid] = res[1][j]
                     zcoeff[tid] = res[2][j]
                     penalty[tid] = res[3][j]

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -312,9 +312,7 @@ def calc_zchi2_targets(targets, templates, mp_procs=1):
             zcoeff = dict()
             penalty = dict()
 
-            for i in range(mp_procs):
-                if len(mpdist[i]) == 0:
-                    continue
+            for _ in range(mp_procs):
                 res = qout.get()
                 for j in range(len(mpdist[res[0]])):
                     zchi2[mpdist[res[0]][j]] = res[1][j]

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -311,8 +311,7 @@ def calc_zchi2_targets(targets, templates, mp_procs=1):
             zchi2 = dict()
             zcoeff = dict()
             penalty = dict()
-
-            for _ in range(mp_procs):
+            for _ in range(len(procs)):
                 res = qout.get()
                 for j in range(len(mpdist[res[0]])):
                     zchi2[mpdist[res[0]][j]] = res[1][j]


### PR DESCRIPTION
This PR fix two bugs:
- `if len(mpdist[i]) == 0:` is wrong because the index is not `i` but is `res[0]`.
also it is useless because at line 283, empty mpdist are not append to mp
- `for j in range(len(mpdist[i])):` was wrong because it was using `i` and
not `res[0]` as an index.
