### PR TITLE
Skymask

### DIFF
--- a/bin/wrap-redrock
+++ b/bin/wrap-redrock
@@ -413,6 +413,14 @@ def main():
     if args.plan:
         plan(args, comm=comm)
     else:
+        #- Create output directory if needed
+        if (args.outdir is not None) and ((comm is None) or (comm.rank == 0)):
+            os.makedirs(args.outdir, exist_ok=True)
+
+        #- All ranks wait for directory to be created
+        if comm is not None:
+            comm.barrier()
+
         run_redrock(args, comm=comm)
 
 if __name__ == '__main__':

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -584,6 +584,13 @@ def rrdesi(options=None, comm=None):
             targetids=targetids, first_target=first_target, n_target=n_target,
             comm=comm, cache_Rcsr=True)
 
+        #- Mask some problematic sky lines
+        for t in targets.local():
+            for s in t.spectra:
+                ii = (5572. <= s.wave) & (s.wave <= 5582.)
+                ii |= (9792. <= s.wave) & (s.wave <= 9795.)
+                s.ivar[ii] = 0.0
+
         # Get the dictionary of wavelength grids
         dwave = targets.wavegrids()
 

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -475,6 +475,9 @@ def rrdesi(options=None, comm=None):
         required=False, help="if not using MPI, the number of multiprocessing"
             " processes to use (defaults to half of the hardware threads)")
 
+    parser.add_argument("--no-skymask", default=False, action="store_true",
+        required=False, help="Do not do extra masking of sky lines")
+
     parser.add_argument("--debug", default=False, action="store_true",
         required=False, help="debug with ipython (only if communicator has a "
         "single process)")
@@ -585,11 +588,12 @@ def rrdesi(options=None, comm=None):
             comm=comm, cache_Rcsr=True)
 
         #- Mask some problematic sky lines
-        for t in targets.local():
-            for s in t.spectra:
-                ii = (5572. <= s.wave) & (s.wave <= 5582.)
-                ii |= (9792. <= s.wave) & (s.wave <= 9795.)
-                s.ivar[ii] = 0.0
+        if not args.no_skymask:
+            for t in targets.local():
+                for s in t.spectra:
+                    ii = (5572. <= s.wave) & (s.wave <= 5582.)
+                    ii |= (9792. <= s.wave) & (s.wave <= 9795.)
+                    s.ivar[ii] = 0.0
 
         # Get the dictionary of wavelength grids
         dwave = targets.wavegrids()

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -167,6 +167,7 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None):
         if targets.comm is not None:
             # MPI case.  Every process just works with its local targets.
             for tg in targets.local():
+                print('----', t.template.redshifts.shape, results[tg.id][ft]['zchi2'].shape)
                 zfit = fitz(results[tg.id][ft]['zchi2'] \
                     + results[tg.id][ft]['penalty'],
                     t.template.redshifts, tg.spectra,

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -167,7 +167,6 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None):
         if targets.comm is not None:
             # MPI case.  Every process just works with its local targets.
             for tg in targets.local():
-                print('----', t.template.redshifts.shape, results[tg.id][ft]['zchi2'].shape)
                 zfit = fitz(results[tg.id][ft]['zchi2'] \
                     + results[tg.id][ft]['penalty'],
                     t.template.redshifts, tg.spectra,


### PR DESCRIPTION
This PR adds a pragmatically motivated mask of two sky lines based upon redshift failures that appear in the pixel level simulations but not the fast simulations:

5577: z=0.4958 puts [OII] on this line and [O I], [S III], and [N II] each line up with other sky residuals in the far red, while H-alpha has nearly redshifted off the detector and is nearly unconstrained.

9793.5 is a bright line on the red end of the Z camera where wavelengths solutions are extrapolated, resulting in frequent mis-subtractions.

The following histograms show the fitted redshift distribution with spikes from these lines.  redrock+archetypes helps a little bit, but the masking helps even more.  It isn't evident from this plote, but masking+archetypes is the best combination.

![zhist](https://user-images.githubusercontent.com/218471/44884605-0d58b780-ac71-11e8-959a-9024b7cc0984.png)

This could be followed up with a more detailed study of all sky lines, but this was a pretty easy improvement for pixel-level sims based upon just these two lines.
