### PR TITLE
standardize ZBEST format

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -449,7 +449,7 @@ def rrdesi(options=None, comm=None):
     parser.add_argument("-o", "--output", type=str, default=None,
         required=False, help="output file")
 
-    parser.add_argument("--zbest", type=str, default=None,
+    parser.add_argument("-z", "--zbest", type=str, default=None,
         required=False, help="output zbest FITS file")
 
     parser.add_argument("--targetids", type=str, default=None,

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -364,4 +364,15 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None):
         for tid in targets.all_target_ids:
             del allresults[tid]['meta']
 
+        # Standardize column sizes
+        if allzfit['subtype'].dtype != '<U20':
+            allzfit.replace_column('subtype', allzfit['subtype'].astype('<U20'))
+
+        maxcoeff = np.max([t.template.nbasis for t in templates])
+        ntarg, ncoeff = allzfit['coeff'].shape
+        if ncoeff != maxcoeff:
+            coeff = np.zeros((ntarg, maxcoeff), dtype=allzfit['coeff'].dtype)
+            coeff[:,0:ncoeff] = allzfit['coeff']
+            allzfit.replace_column('coeff', coeff)
+
     return allresults, allzfit

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -368,6 +368,9 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None):
         if allzfit['subtype'].dtype != '<U20':
             allzfit.replace_column('subtype', allzfit['subtype'].astype('<U20'))
 
+        if allzfit['spectype'].dtype != '<U6':
+            allzfit.replace_column('spectype',allzfit['spectype'].astype('<U6'))
+
         maxcoeff = np.max([t.template.nbasis for t in templates])
         ntarg, ncoeff = allzfit['coeff'].shape
         if ncoeff != maxcoeff:


### PR DESCRIPTION
This PR fixes #140 by enforcing a standard format for the ZBEST table.  In the previous code, the SPECTYPE, SUBTYPE, and COEFF columns could have different dimensions based upon the mix of classifications.