### PR TITLE
Cosmic ray rejection during coaddition of spectra

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -95,11 +95,12 @@ class DistTargetsDESI(DistTargets):
         comm (mpi4py.MPI.Comm): (optional) the MPI communicator.
         cache_Rcsr: pre-calculate and cache sparse CSR format of resolution
             matrix R
+        cosmics_nsig (float): cosmic rejection threshold used in coaddition
     """
 
     ### @profile
     def __init__(self, spectrafiles, coadd=True, targetids=None,
-        first_target=None, n_target=None, comm=None, cache_Rcsr=False):
+                 first_target=None, n_target=None, comm=None, cache_Rcsr=False, cosmics_nsig=0):
 
         comm_size = 1
         comm_rank = 0
@@ -115,6 +116,8 @@ class DistTargetsDESI(DistTargets):
         assert len(spectrafiles) > 0
 
         self._spectrafiles = spectrafiles
+
+        self.cosmics_nsig = cosmics_nsig
 
         # This is the mapping between specs to targets for each file
 
@@ -141,7 +144,7 @@ class DistTargetsDESI(DistTargets):
             nhdu = None
             fmap = None
             if comm_rank == 0:
-                hdus = fits.open(sfile, memmap=True)
+                hdus = fits.open(sfile, memmap=False)
                 nhdu = len(hdus)
                 fmap = encode_table(Table(hdus["FIBERMAP"].data,
                     copy=True).as_array())
@@ -317,7 +320,7 @@ class DistTargetsDESI(DistTargets):
 
             hdus = None
             if comm_rank == 0:
-                hdus = fits.open(sfile, memmap=True)
+                hdus = fits.open(sfile, memmap=False)
 
             for b in self._bands[sfile]:
                 extname = "{}_{}".format(b.upper(), "FLUX")
@@ -408,7 +411,7 @@ class DistTargetsDESI(DistTargets):
 
         if coadd:
             for t in self._my_data:
-                t.compute_coadd(cache_Rcsr)
+                t.compute_coadd(cache_Rcsr,cosmics_nsig=self.cosmics_nsig)
 
         self.fibermap = Table(np.hstack([ self._fmaps[x] \
             for x in self._spectrafiles ]))
@@ -481,7 +484,10 @@ def rrdesi(options=None, comm=None):
     parser.add_argument("--debug", default=False, action="store_true",
         required=False, help="debug with ipython (only if communicator has a "
         "single process)")
-
+    
+    parser.add_argument("--cosmics-nsig", type=float, default=0,
+        required=False, help="n sigma cosmic ray threshold in coaddition")
+    
     parser.add_argument("infiles", nargs='*')
 
     args = None
@@ -584,8 +590,8 @@ def rrdesi(options=None, comm=None):
         # Load the targets.  If comm is None, then the target data will be
         # stored in shared memory.
         targets = DistTargetsDESI(args.infiles, coadd=(not args.allspec),
-            targetids=targetids, first_target=first_target, n_target=n_target,
-            comm=comm, cache_Rcsr=True)
+                                  targetids=targetids, first_target=first_target, n_target=n_target,
+                                  comm=comm, cache_Rcsr=True, cosmics_nsig=args.cosmics_nsig)
 
         #- Mask some problematic sky lines
         if not args.no_skymask:

--- a/py/redrock/targets.py
+++ b/py/redrock/targets.py
@@ -117,10 +117,14 @@ class Target(object):
         meta (dict): optional metadata dictionary for this Target.
 
     """
-    def __init__(self, targetid, spectra, coadd=False, cosmics_nsig=0., meta=dict()):
+    def __init__(self, targetid, spectra, coadd=False, cosmics_nsig=0., meta=None):
         self.id = targetid
         self.spectra = spectra
-        self.meta = meta
+        if meta is None:
+            self.meta = dict()
+        else:
+            self.meta = meta
+
         if coadd:
             self.compute_coadd(cache_Rcsr=False, cosmics_nsig=cosmics_nsig)
 
@@ -132,7 +136,7 @@ class Target(object):
             cache_Rcsr: pre-calculate and cache sparse CSR format of
                 resolution matrix R
             cosmics_nsig (float): number of sigma for cosmic rejection.
-        
+
         This method REPLACES the list of individual spectra with coadds.
         """
         coadd = list()
@@ -163,7 +167,7 @@ class Target(object):
 
                 if cosmics_nsig > 0 :
                     # interpolate over bad measurements
-                    # to be able to compute gradient next 
+                    # to be able to compute gradient next
                     # to a bad pixel and identify oulier
                     # many cosmics residuals are on edge
                     # of cosmic ray trace, and so can be

--- a/py/redrock/targets.py
+++ b/py/redrock/targets.py
@@ -131,7 +131,8 @@ class Target(object):
         Args:
             cache_Rcsr: pre-calculate and cache sparse CSR format of
                 resolution matrix R
-             cosmics_nsig (float): number of sigma for cosmic rejection
+            cosmics_nsig (float): number of sigma for cosmic rejection.
+        
         This method REPLACES the list of individual spectra with coadds.
         """
         coadd = list()


### PR DESCRIPTION
 * gradients of spectra (flux[n+1]-flux[n]) of different exposures to coadd are compared to detect cosmic ray spikes in one of the spectra.
 * new option ```--cosmics-nsig``` in ```rrdesi``` (and ```rrdesi_mpi```). default is 0, i.e. no cosmic ray rejection
 * the method has been tested on the redwood sims. The catastrophic redshift failure rate of ELGs decreases by 1% (from 3% to 2%) for a rejection threshold of 5sigma.
 * the completeness gets lower for lower (more stringent) thresholds, as the false positive rate increases, especially for high S/N spectra (see figure).

```
cosmic ray rejection   efficiency  failure rate
-----------------------------------------------------------------
 no rejection           0.850    0.031
 nsig=5.0		0.856    0.022 
 nsig=4.0		0.853    0.021 
 nsig=3.0		0.823    0.025 
```

Average efficiency for ELG above flux threshold.
![elg-efficiency-vs-oii-flux-threshold-vs-cosmic-ray-rejection](https://user-images.githubusercontent.com/5192160/48294908-57fa6b00-e43c-11e8-8651-b365cb3f865a.png)

Example flagged cosmic ray in coadd (red before, blue after):
![figure_1](https://user-images.githubusercontent.com/5192160/48295175-46b25e00-e43e-11e8-9820-90a40ae8fbcf.png)


