### PR TITLE
Solution for crash of matplotlib interactive window generated by plotspec.py / rrplot

### DIFF
--- a/py/redrock/plotspec.py
+++ b/py/redrock/plotspec.py
@@ -56,7 +56,7 @@ class PlotSpec(object):
 
         plt.ion()
         self.plot()
-        plt.show(block=True)
+        plt.show( block=True )
 
     def _onkeypress(self, event):
         ### print('key', event.key)

--- a/py/redrock/plotspec.py
+++ b/py/redrock/plotspec.py
@@ -56,7 +56,7 @@ class PlotSpec(object):
 
         plt.ion()
         self.plot()
-        plt.show()
+        plt.show(block=True)
 
     def _onkeypress(self, event):
         ### print('key', event.key)


### PR DESCRIPTION
Fix for #159.  Adding block=True to plt.show() in L59 of plotspec.py.  Simple test and works for me.  Tutorial can be rid of ipython workaround aswell.