### PR TITLE
fix plotting subset of input spectra

### DIFF
--- a/py/redrock/plotspec.py
+++ b/py/redrock/plotspec.py
@@ -18,7 +18,14 @@ class PlotSpec(object):
         #- Isolate imports of optional dependencies
         import matplotlib.pyplot as plt
 
-        self.targets = targets
+        #- Only keep targets with fits
+        keeptargets = list()
+        keepids = set(zfit['targetid'])
+        for t in targets:
+            if t.id in keepids:
+                keeptargets.append(t)
+
+        self.targets = keeptargets
         self.templates = templates
         self.archetypes = archetypes
         self.zscan = zscan
@@ -94,6 +101,7 @@ class PlotSpec(object):
         target = self.targets[self.itarget]
         zfit = self.zfit[self.zfit['targetid'] == target.id]
         self.nznum = len(zfit)
+        
         zz = zfit[zfit['znum'] == self.znum][0]
         coeff = zz['coeff']
 

--- a/py/redrock/plotspec.py
+++ b/py/redrock/plotspec.py
@@ -18,7 +18,7 @@ class PlotSpec(object):
         #- Isolate imports of optional dependencies
         import matplotlib.pyplot as plt
 
-        #- Only keep targets with fits
+        #- Only keep targets that are in the zfit table
         keeptargets = list()
         keepids = set(zfit['targetid'])
         for t in targets:
@@ -101,7 +101,6 @@ class PlotSpec(object):
         target = self.targets[self.itarget]
         zfit = self.zfit[self.zfit['targetid'] == target.id]
         self.nznum = len(zfit)
-        
         zz = zfit[zfit['znum'] == self.znum][0]
         coeff = zz['coeff']
 


### PR DESCRIPTION
This PR fixes a bug in plotspec when running on an output file that is a subset of the original input file.  It filters the input targets to the list of targets that actually appear in the redshift catalog file before it tries to plot them.