### PR TITLE
adds --no-mpi-abort option

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -487,6 +487,9 @@ def rrdesi(options=None, comm=None):
     parser.add_argument("--no-skymask", default=False, action="store_true",
         required=False, help="Do not do extra masking of sky lines")
 
+    parser.add_argument("--no-mpi-abort", default=False, action="store_true",
+        required=False, help="Do not call MPI Abort upon failure of a single rank")
+
     parser.add_argument("--debug", default=False, action="store_true",
         required=False, help="debug with ipython (only if communicator has a "
         "single process)")
@@ -659,13 +662,16 @@ def rrdesi(options=None, comm=None):
 
             stop = elapsed(start, "Writing zbest data took", comm=comm)
 
-    except:
+    except Exception as err:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
         lines = [ "Proc {}: {}".format(comm_rank, x) for x in lines ]
+        print("--- Process {} raised an exception ---".format(comm_rank))
         print("".join(lines))
         sys.stdout.flush()
-        if comm is not None:
+        if comm is None or args.no_mpi_abort:
+            raise err
+        else:
             comm.Abort()
 
     global_stop = elapsed(global_start, "Total run time", comm=comm)


### PR DESCRIPTION
This PR adds a `--no-mpi-abort` option to both `rrdesi` and `rrboss` to prevent them from aborting MPI if a rank raises an exception.  This fixes #169 .

The default behavior when running `rrdesi` by itself is to still abort MPI upon failure.  A separate PR in desispec will use `--no-mpi-abort` to avoid the abort and use the TimeoutError signal handler to end rrdesi instead so that it can cleanly kill a single task and move on with the others.