### PR TITLE
use tempfile+rename for output

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ redrock Change Log
 0.14.5 (unreleased)
 -------------------
 
-* No changes yet
+* Use temporary files + rename to avoid partially written files with the
+  final name in case of timeout.
 
 0.14.4 (2020-08-03)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,9 @@ redrock Change Log
 -------------------
 
 * Use temporary files + rename to avoid partially written files with the
-  final name in case of timeout.
+  final name in case of timeout (PR `#186`_).
+
+.. _`#186`: https://github.com/desihub/redrock/pull/186
 
 0.14.4 (2020-08-03)
 -------------------

--- a/py/redrock/external/boss.py
+++ b/py/redrock/external/boss.py
@@ -71,7 +71,10 @@ def write_zbest(outfile, zbest, template_version, archetype_version):
     hx = fits.HDUList()
     hx.append(fits.PrimaryHDU(header=header))
     hx.append(fits.convenience.table_to_hdu(zbest))
-    hx.writeto(os.path.expandvars(outfile), overwrite=True)
+    outfile = os.path.expandvars(outfile)
+    tempfile = outfile + '.tmp'
+    hx.writeto(tempfile, overwrite=True)
+    os.rename(tempfile, outfile)
     return
 
 ### @profile

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -61,7 +61,10 @@ def write_zbest(outfile, zbest, fibermap, template_version, archetype_version):
     hx.append(fits.PrimaryHDU(header=header))
     hx.append(fits.convenience.table_to_hdu(zbest))
     hx.append(fits.convenience.table_to_hdu(fibermap))
-    hx.writeto(os.path.expandvars(outfile), overwrite=True)
+    outfile = os.path.expandvars(outfile)
+    tempfile = outfile + '.tmp'
+    hx.writeto(tempfile, overwrite=True)
+    os.rename(tempfile, outfile)
     return
 
 

--- a/py/redrock/results.py
+++ b/py/redrock/results.py
@@ -4,6 +4,7 @@ Functions for reading and writing full redrock results to HDF5.
 
 from __future__ import absolute_import, division, print_function
 
+import os
 import os.path
 import numpy as np
 from astropy.table import Table
@@ -50,7 +51,8 @@ def write_zscan(filename, zscan, zfit, clobber=False):
     targetids = np.asarray(zbest['targetid'])
     spectypes = list(zscan[targetids[0]].keys())
 
-    fx = h5py.File(filename, mode='w')
+    tempfile = filename + '.tmp'
+    fx = h5py.File(tempfile, mode='w')
     fx['targetids'] = targetids
 
     for spectype in spectypes:
@@ -74,6 +76,7 @@ def write_zscan(filename, zscan, zfit, clobber=False):
         #- TODO: fx['zfit/{}/model']
 
     fx.close()
+    os.rename(tempfile, filename)
 
 
 def read_zscan(filename):


### PR DESCRIPTION
Rongpu found the hard way that redrock wasn't using temporary intermediate files for its output, leading to partially written files with the "final" name in the case of a job timeout.  This PR updates redrock to follow the pattern used in desispec: write a temp file and then rename it only after successfully writing the final file.