### PR TITLE
add dependency keywords to redrock output

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -18,7 +18,7 @@ from astropy.io import fits
 from astropy.table import Table
 
 from desiutil.io import encode_table
-from desiutil.depend import add_dependencies
+from desiutil.depend import add_dependencies, setdep
 
 from desispec.resolution import Resolution
 from desispec.coaddition import coadd_fibermap
@@ -67,7 +67,11 @@ def write_zbest(outfile, zbest, fibermap, exp_fibermap, tsnr2,
             header['ARCNAM'+str(i).zfill(2)] = fulltype
             header['ARCVER'+str(i).zfill(2)] = archetype_version[fulltype]
 
+    # record code versions and key environment variables
     add_dependencies(header)
+    for key in ['RR_TEMPLATE_DIR', 'RR_ARCHETYPE_DIR']:
+        if key in os.environ:
+            setdep(header, key, os.environ[key])
 
     zbest.meta['EXTNAME'] = 'REDSHIFTS'
     fibermap.meta['EXTNAME'] = 'FIBERMAP'

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -18,6 +18,7 @@ from astropy.io import fits
 from astropy.table import Table
 
 from desiutil.io import encode_table
+from desiutil.depend import add_dependencies
 
 from desispec.resolution import Resolution
 from desispec.coaddition import coadd_fibermap
@@ -65,6 +66,9 @@ def write_zbest(outfile, zbest, fibermap, exp_fibermap, tsnr2,
         for i, fulltype in enumerate(archetype_version.keys()):
             header['ARCNAM'+str(i).zfill(2)] = fulltype
             header['ARCVER'+str(i).zfill(2)] = archetype_version[fulltype]
+
+    add_dependencies(header)
+
     zbest.meta['EXTNAME'] = 'REDSHIFTS'
     fibermap.meta['EXTNAME'] = 'FIBERMAP'
     exp_fibermap.meta['EXTNAME'] = 'EXP_FIBERMAP'


### PR DESCRIPTION
This PR calls `desiutil.depend.add_dependencies` and `setdep` on the HDU 0 header of redrock output to restore tracking of code versions and key environment variables like RR_TEMPLATE_DIR.

I did not try to implement generic propagation of input header keywords into the output, since rrdesi supports the ability to take multiple input files and its a bit of a mess to define exactly what we would mean in that case.

I have tested this with a redrock run and plan to self merge.