### PR TITLE
set zwarn LITTLE_COVERAGE for badamp/badcol

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -719,6 +719,11 @@ def rrdesi(options=None, comm=None):
             bad = targets.fibermap['OBJTYPE'] == 'BAD'
             sky = targets.fibermap['OBJTYPE'] == 'SKY'
 
+            badcoverage = np.zeros(len(fiberstatus), dtype=bool)
+            for key in ('BADCOLUMN', 'BADAMPB', 'BADAMPR', 'BADAMPZ'):
+                if key in fibermask.names():
+                    badcoverage |= (fiberstatus & fibermask.mask(key)) != 0
+
             targetids = targets.fibermap['TARGETID']
 
             ii = np.isin(zfit['targetid'], targetids[poorpos])
@@ -732,6 +737,9 @@ def rrdesi(options=None, comm=None):
 
             ii = np.isin(zfit['targetid'], targetids[sky])
             zfit['zwarn'][ii] |= ZWarningMask.SKY
+
+            ii = np.isin(zfit['targetid'], targetids[badcoverage])
+            zfit['zwarn'][ii] |= ZWarningMask.LITTLE_COVERAGE
 
         # Write the outputs
 


### PR DESCRIPTION
In desihub/desispec#1605, bad CCD columns can trigger a BADAMPB/R/Z fiberstatus bit and mask 1/3 of the spectrum, without clobbering the entire spectrum with BADCOLUMN, thus enabling some spectra (like QSOs) to still be fit.

This redrock PR sets a zwarn LITTLE_COVERAGE bit if BADAMPB/R/Z or BADCOLUMN is set because these spectra are still fundamentally different than normal good spectra, analogous to fitting the redshifts for poorly positioned fibers will still flagging them as zwarn POORDATA.

I have tested this with both desispec master (which has fibermask.BADCOLUMN) and desispec from desihub/desispec#1605 which removed that bit to confirm that both work.  All impacted spectra now have ZWARN = LITTLE_COVERAGE set.