### PR TITLE
propagate specgroup related keywords from input

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -80,7 +80,7 @@ def write_zbest(outfile, zbest, fibermap, exp_fibermap, tsnr2,
 
     if spec_header is not None:
         for key in ('SPGRP', 'SPGRPVAL', 'TILEID', 'SPECTRO', 'PETAL',
-                'HPXPIXEL', 'HPXNSIDE', 'HPXNEST'):
+                'NIGHT', 'EXPID', 'HPXPIXEL', 'HPXNSIDE', 'HPXNEST'):
             if key in spec_header:
                 header[key] = spec_header[key]
 

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -43,7 +43,8 @@ from ..archetypes import All_archetypes
 
 
 def write_zbest(outfile, zbest, fibermap, exp_fibermap, tsnr2,
-        template_version, archetype_version):
+        template_version, archetype_version,
+        spec_header=None):
     """Write zbest and fibermap Tables to outfile
 
     Args:
@@ -55,9 +56,13 @@ def write_zbest(outfile, zbest, fibermap, exp_fibermap, tsnr2,
         template_version (str): template version used
         archetype_version (str): archetype version used
 
+    Options:
+        spec_header (dict-like): header of HDU 0 of input spectra
+
     Modifies input tables.meta['EXTNAME']
     """
     header = fits.Header()
+    header['LONGSTRN'] = 'OGIP 1.0'
     header['RRVER'] = (__version__, 'Redrock version')
     for i, fulltype in enumerate(template_version.keys()):
         header['TEMNAM'+str(i).zfill(2)] = fulltype
@@ -72,6 +77,12 @@ def write_zbest(outfile, zbest, fibermap, exp_fibermap, tsnr2,
     for key in ['RR_TEMPLATE_DIR', 'RR_ARCHETYPE_DIR']:
         if key in os.environ:
             setdep(header, key, os.environ[key])
+
+    if spec_header is not None:
+        for key in ('SPGRP', 'SPGRPVAL', 'TILEID', 'SPECTRO', 'PETAL',
+                'HPXPIXEL', 'HPXNSIDE', 'HPXNEST'):
+            if key in spec_header:
+                header[key] = spec_header[key]
 
     zbest.meta['EXTNAME'] = 'REDSHIFTS'
     fibermap.meta['EXTNAME'] = 'FIBERMAP'
@@ -162,6 +173,7 @@ class DistTargetsDESI(DistTargets):
         self._coadd_fmaps = {}
         self._exp_fmaps = {}
         self._tsnr2 = {}         #- template signal-to-noise from SCORES
+        self.header0 = None      #- header 0 of the first spectrafile
 
         for sfile in spectrafiles:
             hdus = None
@@ -173,6 +185,9 @@ class DistTargetsDESI(DistTargets):
             if comm_rank == 0:
                 hdus = fits.open(sfile, memmap=False)
                 nhdu = len(hdus)
+
+                if self.header0 is None:
+                    self.header0 = hdus[0].header.copy()
 
                 if 'EXP_FIBERMAP' in hdus:
                     input_coadded = True
@@ -214,6 +229,7 @@ class DistTargetsDESI(DistTargets):
                 coadd_fmap = comm.bcast(coadd_fmap, root=0)
                 exp_fmap = comm.bcast(exp_fmap, root=0)
                 tsnr2 = comm.bcast(tsnr2, root=0)
+                self.header0 = comm.bcast(self.header0, root=0)
 
             # Now every process has the fibermap and number of HDUs.  Build the
             # mapping between spectral rows and target IDs.
@@ -767,10 +783,12 @@ def rrdesi(options=None, comm=None):
                 if not args.archetypes is None:
                     archetypes = All_archetypes(archetypes_dir=args.archetypes).archetypes
                     archetype_version = {name:arch._version for name, arch in archetypes.items() }
+
                 write_zbest(args.outfile, zbest,
                         targets.fibermap, targets.exp_fibermap,
                         targets.tsnr2,
-                        template_version, archetype_version)
+                        template_version, archetype_version,
+                        spec_header=targets.header0)
 
             stop = elapsed(start, f"Writing {args.outfile} took", comm=comm)
 


### PR DESCRIPTION
This is a companion PR to desihub/desispec#1618 to propagate spectral grouping related keywords to the redrock output.  See desispec#1618 for more details about the keywords and motivation.

Note: In principle redrock can be run on more than one input file and this PR only propagates keywords from the first input file, without checking whether other files are consistent.  This is the minimal change needed for Fuji which only runs on a single file, but might bite us in the future.

@moustakas 