### PR TITLE
propagate SURVEY and PROGRAM to redrock output

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -80,7 +80,8 @@ def write_zbest(outfile, zbest, fibermap, exp_fibermap, tsnr2,
 
     if spec_header is not None:
         for key in ('SPGRP', 'SPGRPVAL', 'TILEID', 'SPECTRO', 'PETAL',
-                'NIGHT', 'EXPID', 'HPXPIXEL', 'HPXNSIDE', 'HPXNEST'):
+                'NIGHT', 'EXPID', 'HPXPIXEL', 'HPXNSIDE', 'HPXNEST',
+                'SURVEY', 'PROGRAM', 'FAPRGRM'):
             if key in spec_header:
                 header[key] = spec_header[key]
 


### PR DESCRIPTION
This PR fixes a metadata bug in Fuji/Guadalupe healpix redshifts, where SURVEY and PROGRAM weren't propagated from the coadd file into the final redrock file.

Rather than rerun all of the healpix redshifts just to get 2 more keywords, I suggest:
  * merge + tag this PR
  * patch pre-existing healpix redrock files with a custom script to add SURVEY and PROGRAM
  * use this PR+tag for any new redshifts run (e.g. cleanup)

Example outputs are in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/zpix/healpix/sv1/dark/271/27133/

* redrock-sv1-dark-27133.fits.orig : original file from Fuji
* redrock-sv1-dark-27133.fits.pr : file produced using this PR
* redrock-sv1-dark-27133.fits.patched : proposed patch of the orig file, which is identical to this PR file except for a few dependency header keywords (e.g. the SPECPROD and DESI_SPECTRO_REDUX used).

Any objections @akremin, @moustakas, or others?

Detail: this is for healpix redshifts, which include the SURVEY and PROGRAM in the coadd headers because that is how they are grouped on disk.  Unfortunately the tile-based redshifts do not have these because due to the evolving nature of these keywords during sv1, we don't necessarily know the SURVEY and PROGRAM of a tile at the time it is being processed.  That's unfortunate, but the tile-based redshifts aren't grouped on disk by that, and they do include their NIGHT/EXPID/etc. keywords to track their grouping.
