### PR TITLE
Add model evaluation routine.

### DIFF
--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -472,7 +472,7 @@ def eval_model(data, wave, R=None, templates=None):
     multiple cameras.
 
     Args:
-        data (array, [nspec]): array containing information on each model to
+        data (table-like, [nspec]): table with information on each model to
             evaluate.  Must contain at least Z, COEFF, SPECTYPE, and SUBTYPE
             fields.
         wave (array [nwave] or dictionary thereof): array of wavelengths in
@@ -483,7 +483,7 @@ def eval_model(data, wave, R=None, templates=None):
             giving the template corresponding to each type.
 
     Returns:
-        model fluxes, array [nspec, nwave].  If wave and R are dictionaries, then
+        model fluxes, array [nspec, nwave].  If wave and R are dict, then
         a dictionary of model fluxes, one for each camera.
     """
     if templates is None:


### PR DESCRIPTION
Add a utility routine for evaluating lots of model spectra.

The goal is to make it easy to evaluate all the spectra on a tile.  e.g., the following now works:
```
spectra, redrock = desispec.io.read_tile_spectra(20140, 20211117, redrock=True, specprod='daily', group='cumulative')
model = templates.eval_model(redrock, spectra.wave, R=spectra.R)
```
though the "group" argument of read_tile_spectra is in another PR on desispec.  This returns a set of model spectra with a structure parallel to spectra---i.e., in the above, model is a dictionary including the brz model spectra that matches spectra.flux.