### PR TITLE
rrdesi if __name__ == "__main__" wrapper

### DIFF
--- a/bin/rrdesi
+++ b/bin/rrdesi
@@ -6,4 +6,5 @@ Redrock for DESI - serial / multiprocessing entry point.
 
 from redrock.external import desi
 
-desi.rrdesi(comm=None)
+if __name__ == '__main__':
+    desi.rrdesi(comm=None)


### PR DESCRIPTION
This PR fixes a problem with rrdesi in multiprocessing mode, which previously would generate the message:
```
(rrtest) temp $ time rrdesi -i coadd-0-100-thru20210505.fits -o redrock-0-100-thru20210505.fits --ntarget 10 
Running with 4 processes
WARNING:  using multiprocessing, but the OMP_NUM_THREADS
WARNING:  environment variable is not set- your system may
WARNING:  be oversubscribed.
Loading targets...
Read and distribution of 10 targets: 0.3 seconds
DEBUG: Read templates from /Users/sbailey/temp/redrock-templates
...
--- Process 0 raised an exception ---
Proc 0: Traceback (most recent call last):
Proc 0:   File "/Users/sbailey/temp/redrock/py/redrock/external/desi.py", line 775, in rrdesi
    dtemplates = load_dist_templates(dwave, templates=args.templates,
Proc 0:   File "/Users/sbailey/temp/redrock/py/redrock/templates.py", line 503, in load_dist_templates
    dtemplate = DistTemplate(t, dwave, mp_procs=mp_procs, comm=comm)
Proc 0:   File "/Users/sbailey/temp/redrock/py/redrock/templates.py", line 298, in __init__
    p.start()
Proc 0:   File "/Users/sbailey/anaconda3/envs/rrtest/lib/python3.8/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
Proc 0:   File "/Users/sbailey/anaconda3/envs/rrtest/lib/python3.8/multiprocessing/context.py", line 224, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
Proc 0:   File "/Users/sbailey/anaconda3/envs/rrtest/lib/python3.8/multiprocessing/context.py", line 284, in _Popen
    return Popen(process_obj)
Proc 0:   File "/Users/sbailey/anaconda3/envs/rrtest/lib/python3.8/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
Proc 0:   File "/Users/sbailey/anaconda3/envs/rrtest/lib/python3.8/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
Proc 0:   File "/Users/sbailey/anaconda3/envs/rrtest/lib/python3.8/multiprocessing/popen_spawn_posix.py", line 42, in _launch
    prep_data = spawn.get_preparation_data(process_obj._name)
Proc 0:   File "/Users/sbailey/anaconda3/envs/rrtest/lib/python3.8/multiprocessing/spawn.py", line 154, in get_preparation_data
    _check_not_importing_main()
Proc 0:   File "/Users/sbailey/anaconda3/envs/rrtest/lib/python3.8/multiprocessing/spawn.py", line 134, in _check_not_importing_main
    raise RuntimeError('''
Proc 0: RuntimeError: 
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```

I think the `freeze_support()` part is only applicable to Windows which we don't support, but wrappering the program in `if __name__ == '__main__'` appears to be required.  rrdesi used to work without that (years ago) so I don't know if the change is to more recent versions of python, something about MacOS X, or just random good/bad luck, but regardless adding the wrapper apparently fixes the problem.

I plan to self-merge this simple fix, but am running it through a PR for the record.