### PR TITLE
avoid bad fits when ranking zchi2 vs. z minima

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -98,6 +98,10 @@ def write_zbest(outfile, zbest, fibermap, exp_fibermap, tsnr2,
     hx.append(fits.convenience.table_to_hdu(tsnr2))
 
     outfile = os.path.expandvars(outfile)
+    outdir = os.path.dirname(os.path.abspath(outfile))
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+
     tempfile = outfile + '.tmp'
     hx.writeto(tempfile, overwrite=True)
     os.rename(tempfile, outfile)

--- a/py/redrock/fitz.py
+++ b/py/redrock/fitz.py
@@ -198,18 +198,18 @@ def fitz(zchi2, redshifts, spectra, template, nminima=3, archetype=None):
         zbest = zmin
         zerr = sigma
 
+        #- parabola minimum outside fit range; replace with min of scan
+        if zbest < zz[0] or zbest > zz[-1]:
+            zwarn |= ZW.BAD_MINFIT
+            imin = np.where(zzchi2 == np.min(zzchi2))[0][0]
+            zbest = zz[imin]
+            chi2min = zzchi2[imin]
+
         #- Initial minimum or best fit too close to edge of redshift range
         if zbest < redshifts[1] or zbest > redshifts[-2]:
             zwarn |= ZW.Z_FITLIMIT
         if zmin < redshifts[1] or zmin > redshifts[-2]:
             zwarn |= ZW.Z_FITLIMIT
-
-        #- parabola minimum outside fit range; replace with min of scan
-        if zbest < zz[0] or zbest > zz[-1]:
-            zwarn |= ZW.BAD_MINFIT
-            imin = np.where(zbest == np.min(zbest))[0][0]
-            zbest = zz[imin]
-            chi2min = zzchi2[imin]
 
         #- Skip this better defined minimum if it is within
         #- constants.max_velo_diff km/s of a previous one

--- a/py/redrock/results.py
+++ b/py/redrock/results.py
@@ -37,6 +37,10 @@ def write_zscan(filename, zscan, zfit, clobber=False):
     if clobber and os.path.exists(filename):
         os.remove(filename)
 
+    outdir = os.path.dirname(os.path.abspath(filename))
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+
     zfit = zfit.copy()
 
     #- convert unicode to byte strings

--- a/py/redrock/test/test_zfind.py
+++ b/py/redrock/test/test_zfind.py
@@ -1,0 +1,117 @@
+import unittest
+from io import BytesIO
+
+import numpy as np
+from astropy.table import Table
+
+from ..zfind import zfind, sort_zfit, calc_deltachi2
+from .. zwarning import ZWarningMask as ZW
+
+class TestZFind(unittest.TestCase):
+    """Test redrock.zfind
+    """
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_sort_zfit(self):
+
+        #- rank by chi2 since zwarn=0 for everyone
+        zfit = Table.read(BytesIO(b"""
+                id zwarn chi2 rank
+                1  0     30   2
+                2  0     20   1
+                3  0     10   0
+                """), format='ascii')
+        sort_zfit(zfit)
+        self.assertEqual(zfit.colnames, ['id', 'zwarn', 'chi2', 'rank'])
+        self.assertEqual(list(zfit['rank']), list(range(len(zfit))))
+
+        #- zwarn Z_FITLIMIT=32 moves id=3 to the end, even with good chi2
+        zfit = Table.read(BytesIO(b"""
+                id zwarn chi2 rank
+                1  0     30   1
+                2  0     20   0
+                3  32    10   2
+                """), format='ascii')
+        sort_zfit(zfit)
+        self.assertEqual(list(zfit['rank']), list(range(len(zfit))))
+
+        #- also test other specific bad bits
+        for bad in (ZW.NEGATIVE_MODEL,
+                    ZW.MANY_OUTLIERS,
+                    ZW.Z_FITLIMIT,
+                    ZW.NEGATIVE_EMISSION,
+                    ZW.BAD_MINFIT):
+            zfit.sort('id')
+            zfit['zwarn'][2] = bad
+            sort_zfit(zfit)
+            self.assertEqual(list(zfit['rank']), list(range(len(zfit))))
+
+        #- zwarn BAD_MINFIT=1024 moves id=3 to the end, even with good chi2
+        zfit = Table.read(BytesIO(b"""
+                id zwarn chi2 rank
+                1  0     30   1
+                2  0     20   0
+                3  1024  10   2
+                """), format='ascii')
+        sort_zfit(zfit)
+        self.assertEqual(list(zfit['rank']), list(range(len(zfit))))
+
+        #- zwarn BAD_TARGET=256 is ok (not about this single fit)
+        zfit = Table.read(BytesIO(b"""
+                id zwarn chi2 rank
+                1  0     30   2
+                2  0     20   1
+                3  256   10   0
+                """), format='ascii')
+        sort_zfit(zfit)
+        self.assertEqual(list(zfit['rank']), list(range(len(zfit))))
+
+        #- test mix of zwarn bits
+        zfit = Table.read(BytesIO(b"""
+                id zwarn chi2 rank
+                1  0     30   1
+                2  256   20   0
+                3  288   10   2
+                """), format='ascii')
+        sort_zfit(zfit)
+        self.assertEqual(list(zfit['rank']), list(range(len(zfit))))
+
+    def test_calc_deltachi2(self):
+
+        #- Well separated redshifts, but some close chi2
+        chi2  = np.array([1.0, 2.0, 20.0, 40.0])
+        z     = np.array([3.0, 3.1,  3.2,  3.3])
+        zwarn = np.array([0,   0,    0,    0])
+        dchi2, setzwarn = calc_deltachi2(chi2, z, zwarn)
+        self.assertTrue(np.all(dchi2 == np.array([1, 18, 20, 0.0])), dchi2)
+        #- Note: setzwarn[1] is True even though deltachi2[1]>9 because it
+        #- is close to the next *better* solution, not just the next worse
+        self.assertTrue(np.all(setzwarn == np.array([True,True,False,False])))
+
+        #- Fits at similar redshifts count as the same solution
+        chi2  = np.array([1.0, 2.0, 20.0, 40.0])
+        z     = np.array([3.0, 3.0001, 4.0, 4.0001])
+        zwarn = np.array([0,   0,    0,    0])
+        dchi2, setzwarn = calc_deltachi2(chi2, z, zwarn)
+        self.assertTrue(np.all(dchi2 == np.array([19, 18, 0.0, 0.0])), dchi2)
+        self.assertTrue(np.all(setzwarn == np.array([False,False,False,False])))
+
+        #- deltachi2 and warning based on next good fit; ignore zwarn=32 entry
+        chi2  = np.array([1.0, 2.0, 20.0, 40.0])
+        z     = np.array([3.0, 3.1,  3.2,  3.3])
+        zwarn = np.array([0,   32,   0,    0])
+        dchi2, setzwarn = calc_deltachi2(chi2, z, zwarn)
+        self.assertTrue(np.all(dchi2 == np.array([19, 18, 20, 0.0])), dchi2)
+        self.assertTrue(np.all(setzwarn == np.array([False,True,False,False])))
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m redrock.test.test_zfind
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/redrock/test/test_zscan.py
+++ b/py/redrock/test/test_zscan.py
@@ -11,7 +11,7 @@ import numpy.testing as nt
 from ..targets import DistTargetsCopy
 from ..templates import DistTemplate
 from ..zscan import calc_zchi2_targets
-from ..zfind import zfind, calc_deltachi2
+from ..zfind import zfind
 
 from . import util
 
@@ -90,16 +90,6 @@ class TestZScan(unittest.TestCase):
         self.assertLess(np.abs(zx2['z'] - z2)/zx2['zerr'], 5)
         self.assertLess(zx1['zerr'], 0.002)
         self.assertLess(zx2['zerr'], 0.002)
-
-    def test_calc_deltachi2(self):
-        chi2 = np.array([1.0, 2.0, 4.0, 8.0])
-        z = np.array([3.0, 3.1, 3.2, 3.3])
-        dchi2 = calc_deltachi2(chi2, z)
-        self.assertTrue(np.all(dchi2 == np.array([1, 2, 4, 0.0])), dchi2)
-
-        z = np.array([3.0, 3.0, 4.0, 4.0])
-        dchi2 = calc_deltachi2(chi2, z)
-        self.assertTrue(np.all(dchi2 == np.array([3, 2, 0.0, 0.0])), dchi2)
 
     def test_parallel_zscan(self):
         z1 = 0.2

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -32,6 +32,7 @@ from .zscan import calc_zchi2_targets
 from .fitz import fitz, get_dv
 
 from .zwarning import ZWarningMask as ZW
+from .zwarning import badfit_mask
 
 
 def _mp_fitz(chi2, target_data, t, nminima, qout, archetype):
@@ -57,33 +58,52 @@ def _mp_fitz(chi2, target_data, t, nminima, qout, archetype):
         print("".join(lines))
         sys.stdout.flush()
 
-def calc_deltachi2(chi2, z, dvlimit=None):
+def calc_deltachi2(chi2, z, zwarn, dvlimit=constants.max_velo_diff):
     '''
-    Calculate chi2 differences, excluding candidates with close z
+    Calculate chi2 differences, excluding candidates with close z or bad fits
 
     Args:
         chi2 : array of chi2 values
         z : array of redshifts
+        zwarn : array of zwarn values
 
     Options:
         dvlimit: exclude candidates that are closer than dvlimit [km/s]
+
+    Returns (deltachi2, setzwarn) where `deltachi2` is array of chi2 differences
+        to next best good fit, and `setzwarn` is boolean array of whether
+        a SMALL_DELTACHI2 zwarn bit should be set.
 
     Note: The final target always has deltachi2=0.0 because we don't know
         what the next chi2 would have been.  This can also occur for the
         last N targets if all N of them are within dvlimit of each other.
     '''
-    if dvlimit is None:
-        dvlimit = constants.max_velo_diff
-
-    deltachi2 = np.zeros(len(chi2))
+    nz = len(chi2)
+    deltachi2 = np.zeros(nz)
+    okfit = (zwarn & badfit_mask) == 0
     for i in range(len(chi2)-1):
         dv = get_dv(z[i+1:], z[i])
-        ii = np.abs(dv)>dvlimit
+        ii = (np.abs(dv)>dvlimit) & okfit[i+1:]
         if np.any(ii):
             dchi2 = chi2[i+1:] - chi2[i]
             deltachi2[i] = np.min(dchi2[ii])
 
-    return deltachi2
+    #- zwarn SMALL_DELTA_CHI2 is based upon small difference to any good fit,
+    #- including a slightly better one
+    noti = np.ones(nz, dtype=bool)
+    setzwarn = np.zeros(nz, dtype=bool)
+    for i in range(nz):
+        noti[:] = True
+        noti[i] = False
+        alldeltachi2 = np.absolute(chi2[noti] - chi2[i])
+        alldv = np.absolute(get_dv(z=z[noti], zref=z[i]))
+        zwarn = np.any( okfit[noti] &
+                    (alldeltachi2 < constants.min_deltachi2) &
+                    (alldv >= dvlimit) )
+        if zwarn:
+            setzwarn[i] = True
+
+    return deltachi2, setzwarn
 
 
 def _rebalance_after_scan(targets, results):
@@ -114,6 +134,18 @@ def _rebalance_after_scan(targets, results):
 
     return local_targets, results
 
+def sort_zfit(zfit):
+    """
+    Sorts zfit table by goodness of fit, using 'zwarn' and 'chi2' columns
+
+    Args:
+        zfit: astropy Table with columns 'zwarn' and 'chi2'
+
+    Modifies zfit in-place by sorting it
+    """
+    zfit['__badfit__'] = (zfit['zwarn'] & badfit_mask) != 0
+    zfit.sort( ('__badfit__', 'chi2') )
+    zfit.remove_column('__badfit__')
 
 def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=None, chi2_scan=None, use_gpu=False):
     """Compute all redshift fits for the local set of targets and collect.
@@ -330,29 +362,16 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
                     tmp.replace_column('coeff', c)
 
             tzfit = astropy.table.vstack(tzfit)
-            tzfit.sort('chi2')
             tzfit['targetid'] = tid
-            tzfit['znum'] = np.arange(len(tzfit))
-            tzfit['zwarn'][ tzfit['npixels']==0 ] |= ZW.NODATA
-            tzfit['zwarn'][ (tzfit['npixels']<10*tzfit['ncoeff']) ] |= \
-                ZW.LITTLE_COVERAGE
             if archetypes:
                 tzfit['zwarn'][ tzfit['coeff'][:,0]<=0. ] |= ZW.NEGATIVE_MODEL
 
-            #- set ZW.SMALL_DELTA_CHI2 flag
-            tzfit['deltachi2'] = calc_deltachi2(tzfit['chi2'], tzfit['z'])
-            ii = (tzfit['deltachi2'] < constants.min_deltachi2)
-            tzfit['zwarn'][ii] |= ZW.SMALL_DELTA_CHI2
+            tzfit['zwarn'][ tzfit['npixels']==0 ] |= ZW.NODATA
+            tzfit['zwarn'][ (tzfit['npixels']<10*tzfit['ncoeff']) ] |= \
+                ZW.LITTLE_COVERAGE
 
-            for i in range(len(tzfit)-1):
-                noti = (np.arange(len(tzfit))!=i)
-                alldeltachi2 = np.absolute(tzfit['chi2'][noti]-tzfit['chi2'][i])
-                alldv = np.absolute(get_dv(z=tzfit['z'][noti],
-                    zref=tzfit['z'][i]))
-                zwarn = np.any( (alldeltachi2<constants.min_deltachi2) & \
-                    (alldv>=constants.max_velo_diff) )
-                if zwarn:
-                    tzfit['zwarn'][i] |= ZW.SMALL_DELTA_CHI2
+            #- Sort by badfit zwarn bits and chi2
+            sort_zfit(tzfit)
 
             # Trim down cases of multiple subtypes for a single type (e.g.
             # STARs) tzfit is already sorted by chi2, so keep first nminima of
@@ -363,10 +382,17 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
                 iikeep.extend(ii[0:nminima])
             if len(iikeep) < len(tzfit):
                 tzfit = tzfit[iikeep]
-                #- grouping by spectype could get chi2 out of order; resort
-                tzfit.sort('chi2')
+                #- grouping by spectype could get chi2 out of order so re-sort
+                sort_zfit(tzfit)
 
+            #- Add ranking column 'znum'
             tzfit['znum'] = np.arange(len(tzfit))
+
+            #- calc deltachi2 and set ZW.SMALL_DELTA_CHI2 flag
+            deltachi2, setzwarn = calc_deltachi2(
+                    tzfit['chi2'], tzfit['z'], tzfit['zwarn'])
+            tzfit['deltachi2'] = deltachi2
+            tzfit['zwarn'][setzwarn] |= ZW.SMALL_DELTA_CHI2
 
             # Store
             allzfit.append(tzfit)

--- a/py/redrock/zwarning.py
+++ b/py/redrock/zwarning.py
@@ -47,3 +47,10 @@ class ZWarningMask(object):
         isort = np.argsort([x[1] for x in flagmask])
         flagmask = [flagmask[i] for i in isort]
         return flagmask
+
+#- mask of zwarn values that indicate bad individual template fits
+badfit_mask = ZWarningMask.NEGATIVE_MODEL
+badfit_mask |= ZWarningMask.MANY_OUTLIERS
+badfit_mask |= ZWarningMask.Z_FITLIMIT
+badfit_mask |= ZWarningMask.NEGATIVE_EMISSION
+badfit_mask |= ZWarningMask.BAD_MINFIT


### PR DESCRIPTION
This PR fixes #214 by avoiding bad fits when ranking the zchi2 vs. z minima for each target.  `redrock.zwarning.badfit_mask` defines the bits that are considered bad fits and thus moved to the end of the ranking even if they claim to have better chi2 than a good fit.  These are NEGATIVE_MODEL, MANY_OUTLIERS, Z_FITLIMIT, NEGATIVE_EMISSION, BAD_MINFIT (not all of those are set yet, but they could be in the future).

For template classes with subtypes (STARS, and in the future QSOs), this PR also trims to the 3 best solutions of each SPECTYPE before calculating DELTACHI2.  Previously there was the possibility that the DELTACHI2 for a GALAXY fit could be relative to the 4th best fit of a STAR that was later removed from the list.  This change doesn't impact the DELTACHI2 and SMALL_DELTACHI2 flag of the best fit.

`calc_deltachi2` (and thus also the zwarn SMALL_DELTACHI2 bit) now only calculates a deltachi2 relative to a good fit, not to bad fits, avoiding the case where a bad fit has an incorrectly low chi2 and triggers a zwarn bit for another good fit.

Other changes that came along for the ride:
  * fix a bug where a fit could be at the redshift limit for a template, while (previously) only having BAD_MINFIT set but not Z_FITLIMIT
  * create the output directory if needed prior to writing the file (instead of crashing)
  * better tests for `calc_deltachi2` and (new) `sort_zfit`

An example output is in `/global/cfs/cdirs/desi/users/sjbailey/debug/qsotemplates/test1/tiles/cumulative/1422/20210604/redrock-9-1422-thru20210604.fits` to be compared with `/global/cfs/cdirs/desi/users/rongpu/redux/guadalupe/cumulative_new_qso_templates/1422/20210604/redrock-9-1422-thru20210604.fits`.  These used the templates in `/global/cfs/cdirs/desi/users/sjbailey/debug/qsotemplates/redrock-templates`, i.e. current galaxy and star templates, and @abrodze new loz/hiz QSO templates.

There are 3 targets that were previously at the z=1.4 limit of the new highz QSO templates, but are not selected as the lowz QSO templates just below z=1.4:
```
Previous:
     TARGETID     SPECTYPE    SUBTYPE       Z    ZWARN        CHI2
      int64        bytes6     bytes20    float64 int64      float64
----------------- -------- ------------- ------- ----- -----------------
39628257267555822      QSO HIGH REDSHIFT     1.4  1024 8019.874508363009
39628240150594201      QSO HIGH REDSHIFT     1.4  1056 8201.379073445436
39628240154787962      QSO HIGH REDSHIFT     1.4  1024 7808.403566556876

New:
     TARGETID     SPECTYPE   SUBTYPE            Z          ZWARN        CHI2
      int64        bytes6    bytes20         float64       int64      float64
----------------- -------- ------------ ------------------ ----- ------------------
39628257267555822      QSO LOW REDSHIFT 1.3924721410924068     0 8024.9919535294175
39628240150594201      QSO LOW REDSHIFT 1.3989342092467512     0  9050.572885281406
39628240154787962      QSO LOW REDSHIFT 1.3946024112334179     0  7866.824881831184
```
Note that two of these are the case where the current code is at the z=1.4 limit but incorrectly isn't setting bit 5 "Z_FITLIMIT".

It appears that for these targets the high redshift templates are generating better fits, but that they don't quite go low enough to get the correct redshift just below z=1.4.  That could be explored in future template work.

Another detail: for targets with entirely masked spectra, all of the fits are junk (with zwarn NODATA, LITTLE_COVERAGE, and possibly other bits set) and the resorting in this PR can result in a different junk solution being the "best", but they are zwarn flagged anyway.

@abrodze and @rongpu could you take a look at this?  Also heads up @kdawson1000 I think this implements the logic we discussed on my whiteboard.

Example run with this branch:
```
cd /global/cfs/cdirs/desi/users/sjbailey/debug/qsotemplates
export RR_TEMPLATE_DIR=/global/cfs/cdirs/desi/users/sjbailey/debug/qsotemplates/redrock-templates
time srun -n $(($SLURM_CPUS_ON_NODE/2)) -c 2 rrdesi_mpi \
         -i $rx/guadalupe/tiles/cumulative/1422/20210604/coadd-9-1422-thru20210604.fits \
         -o test1/tiles/cumulative/1422/20210604/redrock-9-1422-thru20210604.fits \
         -d test1/tiles/cumulative/1422/20210604/rrdetails-9-1422-thru20210604.h5
```

I could run more cases, but that "z=1.4 pileup" is typically 0 or 1 cases per petal per exposure, so I only tested in detail on this case I found with 3 z=1.4 targets.
