### PR TITLE
Modified unit tests to ensure that both cupy install and CUDA device

### DIFF
--- a/py/redrock/test/test_rebin.py
+++ b/py/redrock/test/test_rebin.py
@@ -4,7 +4,7 @@ import numpy as np
 cp_available = False
 try:
     import cupy as cp
-    cp_available = True
+    cp_available = cp.is_available()
 except Exception:
     cp_available = False
 
@@ -85,11 +85,9 @@ class TestRebin(unittest.TestCase):
         self.assertTrue(np.allclose(yy[0:2], 2/np.pi, atol=5e-4))
         self.assertTrue(np.allclose(yy[2:4], -2/np.pi, atol=5e-4))
 
+    @unittest.skipUnless(cp_available, "Skipping test_gpu_trapzrebin because no GPU found.")
     def test_gpu_trapzrebin(self):
         '''Test that GPU version matches CPU for constant flux density at various binnings'''
-        if (not cp_available):
-            self.assertTrue(True)
-            return
         nx = 10
         x = np.arange(nx)*1.1
         y = np.ones(nx)
@@ -110,11 +108,9 @@ class TestRebin(unittest.TestCase):
             self.assertTrue(np.allclose(yy, 1.0), msg=str(yy))
             self.assertTrue(type(yy) == cp.ndarray)
 
+    @unittest.skipUnless(cp_available, "Skipping test_gpu_trapzrebin_uneven because no GPU found.")
     def test_gpu_trapzrebin_uneven(self):
         '''test rebinning unevenly spaced x for GPU vs CPU'''
-        if (not cp_available):
-            self.assertTrue(True)
-            return
         x = np.linspace(0, 10, 100)**2
         y = np.sqrt(x)
         edges = np.linspace(0,100,21)
@@ -124,11 +120,9 @@ class TestRebin(unittest.TestCase):
         self.assertTrue(type(g) == cp.ndarray)
         self.assertTrue(type(c) == np.ndarray)
 
+    @unittest.skipUnless(cp_available, "Skipping test_gpu_trapzrebin_multidimensional because no GPU found.")
     def test_gpu_trapzrebin_multidimensional(self):
         '''Test that batch CPU and GPU matches CPU 1d version'''
-        if (not cp_available):
-            self.assertTrue(True)
-            return
         #First test multiple bases, no redshifts
         x = np.arange(10)
         y = np.ones((2,10)) #nbasis = 2

--- a/py/redrock/test/test_utils.py
+++ b/py/redrock/test/test_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 cp_available = False
 try:
     import cupy as cp
-    cp_available = True
+    cp_available = cp.is_available() 
 except Exception:
     cp_available = False
 
@@ -50,12 +50,10 @@ class TestUtils(unittest.TestCase):
             self.assertTrue(np.allclose(c[i], a))
             self.assertTrue(type(a) == np.ndarray)
 
+    @unittest.skipUnless(cp_available, "Skipping test_Lyman_transmission_GPU because no GPU found.")
     def test_Lyman_transmission_GPU(self):
         '''Test the GPU version of Lyman transmission in batch versus
         both the 2D mode and the legacy 1D mode'''
-        if (not cp_available):
-            self.assertTrue(True)
-            return
         x = np.arange(300)+800.
         myz = np.arange(11)*0.1
 

--- a/py/redrock/test/test_zscan.py
+++ b/py/redrock/test/test_zscan.py
@@ -18,7 +18,7 @@ from . import util
 cp_available = False
 try:
     import cupy as cp
-    cp_available = True
+    cp_available = cp.is_available()
 except Exception:
     cp_available = False
 
@@ -139,10 +139,8 @@ class TestZScan(unittest.TestCase):
             self.assertTrue(np.all(resa['zchi2'] == resb['zchi2']))
             self.assertTrue(np.all(resa['zcoeff'] == resb['zcoeff']))
 
+    @unittest.skipUnless(cp_available, "Skipping test_gpu_zscan because no GPU found.")
     def test_gpu_zscan(self):
-        if (not cp_available):
-            self.assertTrue(True)
-            return
         z1 = 0.2
         z2 = 0.25
         seed = np.random.randint(2**31)


### PR DESCRIPTION
available for cp_available global var to be True.  Also modified to use unittest.skipUnless to skip GPU tests if not available.

This closes issue #227.