### PR TITLE
Add modules to api.rst

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W --keep-going
 # For macports, use the second line...
 SPHINXBUILD   = sphinx-build
 # SPHINXBUILD   = sphinx-build-2.7

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -17,6 +17,9 @@ If you're loading a module here, and don't see some functions, try adding the
 .. automodule:: redrock
     :members:
 
+.. automodule:: redrock.archetypes
+    :members:
+
 .. automodule:: redrock.constants
     :members:
 
@@ -33,6 +36,9 @@ If you're loading a module here, and don't see some functions, try adding the
     :members:
 
 .. automodule:: redrock.plotspec
+    :members:
+
+.. automodule:: redrock.priors
     :members:
 
 .. automodule:: redrock.rebin

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ redrock Change Log
 0.17.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Update API documentation for completeness.
 
 0.17.0 (2023-01-12)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ redrock Change Log
 0.17.1 (unreleased)
 -------------------
 
-* Update API documentation for completeness.
+* Update API documentation for completeness (PR `#229`_).
+
+.. _`#229`: https://github.com/desihub/redrock/pull/229
 
 0.17.0 (2023-01-12)
 -------------------

--- a/py/redrock/archetypes.py
+++ b/py/redrock/archetypes.py
@@ -1,4 +1,7 @@
 """
+redrock.archetypes
+==================
+
 Classes and functions for archetypes.
 """
 

--- a/py/redrock/priors.py
+++ b/py/redrock/priors.py
@@ -1,4 +1,7 @@
 """
+redrock.priors
+==============
+
 Classes and functions for priors.
 """
 
@@ -8,13 +11,16 @@ import numpy as np
 
 class Priors():
     """Class to store all different redshift priors.
+
     Args:
         filename (str): the path to the redshift prior file.
-        The file should have at least one HDU with
-        EXTNAME='PRIORS', composed of:
-            TARGETID: the id of the object
-            Z: the mean of the prior
-            SIGMA: the sigma (in dz) for the prior
+
+    Note:
+        The file should have at least one HDU with EXTNAME='PRIORS', composed of:
+
+        * TARGETID: the id of the object
+        * Z: the mean of the prior
+        * SIGMA: the sigma (in dz) for the prior
     """
     def __init__(self, filename):
 
@@ -82,30 +88,34 @@ class Priors():
     @staticmethod
     def tophat(z, z0, s0):
         """Return a tophat prior of mean z0 and width s0 on the grid z.
-           Warning :
-                * np.NaN <= np.NaN -> False
-                * np.NaN <=/>= 0.0  -> False
-                * np.inf >= 0.0 -> True
-                * np.inf >= np.inf -> True
-           Conclusion:
-               * We need to use np.Nan value and not 1e10 value outside the prior to avoid
-                 the case where they are only one or two minima in the tophat
-                 since otherwise the second/third minima will be selected outside the prior
-               * Cannot use np.inf value for that since np.inf <= np.inf is True ...
-               * Need to had np.inf value in the left and right of the tophat in the case where
-               the minima is the first or the last point !
+
         Args:
             z : redshift grid
             z0 : mean
             s0 : width
+
         Returns:
             prior values on the redshift grid.
+
+        Warning:
+            * np.NaN <= np.NaN -> False
+            * np.NaN <=/>= 0.0  -> False
+            * np.inf >= 0.0 -> True
+            * np.inf >= np.inf -> True
+
+        Todo:
+            * We need to use np.Nan value and not 1e10 value outside the prior to avoid
+              the case where they are only one or two minima in the tophat
+              since otherwise the second/third minima will be selected outside the prior
+            * Cannot use np.inf value for that since np.inf <= np.inf is True ...
+            * Need to had np.inf value in the left and right of the tophat in the case where
+              the minima is the first or the last point !
         """
-        
+
         prior = np.where(np.abs(z - z0) < s0/2, 0., np.NaN)
- 
+
         index_left, index_right = np.argwhere(prior>=0.0)[0], np.argwhere(prior>=0.0)[-1]
-    
+
         if index_left == 0:
             prior[index_left] = np.inf
         else:

--- a/py/redrock/results.py
+++ b/py/redrock/results.py
@@ -1,4 +1,7 @@
 """
+redrock.results
+===============
+
 Functions for reading and writing full redrock results to HDF5.
 """
 

--- a/py/redrock/targets.py
+++ b/py/redrock/targets.py
@@ -1,4 +1,7 @@
 """
+redrock.targets
+===============
+
 Classes and functions for targets and their spectra.
 """
 

--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -1,4 +1,7 @@
 """
+redrock.templates
+=================
+
 Classes and functions for templates.
 """
 

--- a/py/redrock/utils.py
+++ b/py/redrock/utils.py
@@ -1,4 +1,7 @@
 """
+redrock.utils
+=============
+
 Redrock utility functions.
 """
 


### PR DESCRIPTION
In the process of reviewing all DESI packages for API documentation completeness, I found that the `api.rst` file was missing `redrock.archetypes` and `redrock.priors`.