### PR TITLE
Fix to force mpprocs = 1 when using GPU mode with multiprocessing.

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -731,6 +731,12 @@ def rrdesi(options=None, comm=None):
             gpu_proc_flags = comm.allgather(use_gpu)
         else:
             gpu_proc_flags = [use_gpu, ]
+            if (mpprocs > 1):
+                #Force mpprocs == 1 for multiprocessing mode with GPU
+                print("WARNING:  using GPU mode without MPI requires --mp 1")
+                print("WARNING:  Overriding {} multiprocesses to force this.".format(mpprocs))
+                print("WARNING:  Running with 1 process.")
+                mpprocs = 1
         ngpu_procs = sum(gpu_proc_flags)
         ncpu_procs = comm_size - ngpu_procs
         if ngpu_procs > 0 and ncpu_procs > 0:

--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -295,7 +295,7 @@ class DistTemplate(object):
         # all the templates.  In that scenario, use multiprocessing
         # workers to do the rebinning.
 
-        if self._comm is not None:
+        if self._comm is not None or mp_procs == 1:
             # MPI case- compute our local redshifts
             # This will rebin template for all z on either GPU or CPU and
             # return a dict of three 3-d arrays (nz x nlambda x nbasis)
@@ -328,6 +328,8 @@ class DistTemplate(object):
                 data[key] = list()
                 for i in range(mp_procs):
                     data[key].append(results[i][key])
+                #Ok to leave this np.vstack because GPU code doesn't enter
+                #this if block since it requires mp_procs == 1
                 data[key] = np.vstack(data[key])
 
         # Correct spectra for Lyman-series

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -325,7 +325,7 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
         # Here we have another parallelization choice between MPI and
         # multiprocessing.
 
-        if targets.comm is not None:
+        if targets.comm is not None or mp_procs == 1:
             # MPI case.  Every process just works with its local targets.
             for tg in local_targets:
                 zfit = fitz(results[tg.id][ft]['zchi2'] \


### PR DESCRIPTION
GPU and multiprocessing do not play well together and mp start method must be set to spawn or forkserver to run with cupy code but the overhead inherent in these methods makes this a nonstarter. However GPU code is so fast that with --mp 1 and GPU mode is more than twice as fast as --mp 64 with no GPU.

This makes --mp 1 a special case where we forego using mp.Queue() object and follow the MPI path instead.  This also results in about a 30% speed-up on CPU with --mp 1.

Options available are:
1) MPI + CPU multiple processes
2) MPI + GPU multiple processes
3) GPU single multiprocessing process
4) CPU multiple multiprocessing processes