### PR TITLE
Remove multiprocessing from rebin

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -731,6 +731,12 @@ def rrdesi(options=None, comm=None):
             gpu_proc_flags = comm.allgather(use_gpu)
         else:
             gpu_proc_flags = [use_gpu, ]
+            if (mpprocs > 1):
+                #Force mpprocs == 1 for multiprocessing mode with GPU
+                print("WARNING:  using GPU mode without MPI requires --mp 1")
+                print("WARNING:  Overriding {} multiprocesses to force this.".format(mpprocs))
+                print("WARNING:  Running with 1 process.")
+                mpprocs = 1
         ngpu_procs = sum(gpu_proc_flags)
         ncpu_procs = comm_size - ngpu_procs
         if ngpu_procs > 0 and ncpu_procs > 0:

--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -295,7 +295,7 @@ class DistTemplate(object):
         # all the templates.  In that scenario, use multiprocessing
         # workers to do the rebinning.
 
-        if self._comm is not None:
+        if self._comm is not None or mp_procs == 1:
             # MPI case- compute our local redshifts
             # This will rebin template for all z on either GPU or CPU and
             # return a dict of three 3-d arrays (nz x nlambda x nbasis)
@@ -328,6 +328,8 @@ class DistTemplate(object):
                 data[key] = list()
                 for i in range(mp_procs):
                     data[key].append(results[i][key])
+                #Ok to leave this np.vstack because GPU code doesn't enter
+                #this if block since it requires mp_procs == 1
                 data[key] = np.vstack(data[key])
 
         # Correct spectra for Lyman-series

--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -295,42 +295,12 @@ class DistTemplate(object):
         # all the templates.  In that scenario, use multiprocessing
         # workers to do the rebinning.
 
-        if self._comm is not None or mp_procs == 1:
-            # MPI case- compute our local redshifts
-            # This will rebin template for all z on either GPU or CPU and
-            # return a dict of three 3-d arrays (nz x nlambda x nbasis)
-            data = rebin_template(self._template, myz, self._dwave, use_gpu=use_gpu)
-        else:
-            # We don't have MPI, so use multiprocessing
-            import multiprocessing as mp
-
-            qout = mp.Queue()
-            #Split myz to various mp procs
-            work = np.array_split(myz, mp_procs)
-            procs = list()
-            for i in range(mp_procs):
-                p = mp.Process(target=_mp_rebin_template,
-                    args=(self._template, self._dwave, work[i], qout, i, use_gpu))
-                procs.append(p)
-                p.start()
-
-            # Extract the output into a single dictionary
-            # First create a dictionary keyed by process number to keep
-            # redshifts in order.
-            results = dict()
-            data = dict()
-            for i in range(mp_procs):
-                res = qout.get()
-                results.update(res)
-            # Then use np.vstack to combine into a dict of
-            # three 3-d arrays
-            for key in results[0]:
-                data[key] = list()
-                for i in range(mp_procs):
-                    data[key].append(results[i][key])
-                #Ok to leave this np.vstack because GPU code doesn't enter
-                #this if block since it requires mp_procs == 1
-                data[key] = np.vstack(data[key])
+        # Removed MPI vs multiprocessing branch - CW 2/8/23
+        # faster to just call rebin_template on one proc without using mp.Queue
+        # compute our local redshifts
+        # This will rebin template for all z on either GPU or CPU and
+        # return a dict of three 3-d arrays (nz x nlambda x nbasis)
+        data = rebin_template(self._template, myz, self._dwave, use_gpu=use_gpu)
 
         # Correct spectra for Lyman-series
         for k in list(self._dwave.keys()):

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -325,7 +325,7 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
         # Here we have another parallelization choice between MPI and
         # multiprocessing.
 
-        if targets.comm is not None:
+        if targets.comm is not None or mp_procs == 1:
             # MPI case.  Every process just works with its local targets.
             for tg in local_targets:
                 zfit = fitz(results[tg.id][ft]['zchi2'] \


### PR DESCRIPTION
Removed the multiprocessing branch for rebinning templates because using mp.Queue resulted in slower runtime than performing `rebin_template` on a single proc.