### PR TITLE
Bugfix for crashes/hangs when MPI ranks > ntargets.

### DIFF
--- a/py/redrock/rebin.py
+++ b/py/redrock/rebin.py
@@ -293,6 +293,9 @@ def trapz_rebin(x, y, xnew=None, edges=None, myz=None, use_gpu=False):
         scalar_z = True
     myz = np.asarray(myz, dtype=np.float64)
     nz = len(myz)
+    if (nz == 0):
+        #Empty myz array
+        return np.zeros((0,nbins, 1), dtype=np.float64)
 
     #Must multiply x by 1+z for comparison, only need to look at max/min cases
     if (edges[0] < x[0]*(1+myz.max()) or edges[-1] > x[-1]*(1+myz.min())):

--- a/py/redrock/utils.py
+++ b/py/redrock/utils.py
@@ -256,6 +256,9 @@ def transmission_Lyman(zObj,lObs, use_gpu=False):
         #zObj is a float
         lRF = lObs/(1.+zObj)
     else:
+        if (len(zObj) == 0):
+            #Empty z array
+            return np.ones((0, len(lObs)), dtype=np.float64)
         #This is an array of float
         if (lObs.min()/(1+zObj.max()) > Lyman_series['Lya']['line']):
             #Return None if wavelength range doesn't overlap with Lyman series

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -830,7 +830,7 @@ def calc_zchi2_targets(targets, templates, mp_procs=1, use_gpu=False):
             #have 0 targets.  Set done to true in these cases so it skips the
             #while loop - this saves ~2s on 500 targets on 64 CPU / 4 GPU
             #and no need to call calc_zchi2 on empty target list
-            if (len(targets.local_target_ids()) == 0):
+            if (use_gpu and len(targets.local_target_ids()) == 0):
                 done = True
             while not done:
                 # Compute the fit for our current redshift slice.


### PR DESCRIPTION
rebin_template and transmission_Lyman are both passed z arrays created from master redshift list using np.array_split and those arrays can be empty if MPI ranks > ntargets.  In these cases, return output array of size 0 in nz dimension and correct other dimensions (empty array). Also one line change needed in in zscan for non-GPU case of having 0 targets for a given MPI rank to reach the t.cycle() call (in GPU mode, cycle is a no-op)