### PR TITLE
Refactored np.linalg.solve (and cp.linalg.solve) into solve_matrices …

### DIFF
--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -141,6 +141,18 @@ class Template(object):
     def redshifts(self):
         return self._redshifts
 
+    @property
+    def solve_matrices_algorithm(self):
+        """Return a string representing the algorithm to be used in
+        zscan.solve_matrices.  Possible values are:
+        PCA
+        NMF
+        Logic can be added here to select a default algorithm based on header
+        keywords etc so that different templates seamlessly use different
+        algorithms.
+        """
+        return "PCA"
+
 
     def eval(self, coeff, wave, z):
         """Return template for given coefficients, wavelengths, and redshift


### PR DESCRIPTION
…wrapper,

which will support additional algorithms such as NMF for solving the
system of matrices y = M*x for x.   Support added to the Template class to
have the property solve_matrices_algorithm, which is a string represnting
the algorithm to use.  In this way the algorithm can be chosen by any
criteria in a template such as on the basis of a header value and different
templates can use different algorithms in the same run.