### PR TITLE
resolved array reshape in fulltype

### DIFF
--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -410,17 +410,20 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
                         spectype, subtype = fulltype.split(':::')
                     else:
                         spectype, subtype = (fulltype, '')
+                    nmin = len(tmp['chi2']) # defining dimension of array to save fulltype
                 else:
-                    spectype = [ el.split(':::')[0] for el in tmp['fulltype'] ]
-                    subtype = [ el.split(':::')[1] for el in tmp['fulltype'] ]
-                    tmp.remove_column('fulltype')
+                    spectype = [ el[0].split(':::')[0] for el in tmp['fulltype'] ] #el is a list with one element (corresponding to each minima)
+                    subtype = [ el[0].split(':::')[1] for el in tmp['fulltype'] ]
+                    del tmp['fulltype'] #it's a dictionary
+                    nmin=1 # defining dimension of array to save fulltype (spectype and subtype are already a list with len(tmp['chi2']) elements
+                    #tmp.remove_column('fulltype')
 
                 #Have to create arrays of correct length since using dict of
                 #np arrays instead of astropy Table
                 l = len(tmp['chi2'])
-                tmp['spectype'] = np.array([spectype]*l).reshape((l, 1))
-                tmp['subtype'] = np.array([subtype]*l).reshape((l, 1))
-
+                tmp['spectype'] = np.array([spectype]*nmin).reshape((l, 1))
+                tmp['subtype'] = np.array([subtype]*nmin).reshape((l, 1))
+                
                 tmp['ncoeff'] = np.array([tmp['coeff'].shape[1]]*l).reshape((l, 1))
                 tzfit.append(tmp)
                 del allresults[tid][fulltype]['zfit']


### PR DESCRIPTION
In the `zfind.py` there was an issue in creating fulltype (spectype and subtype) array for the best fits redshifts when `rrdesi` is run in archetype mode.

**Description of issue:** 

When redrock is run without archetypes, the fulltype for an object could be 'GALAXY:::', 'QSO:::LOZ' or 'STAR:::A' ... etc, which is split as spectype and subtype as strings as following:

`spectype, subtype = fulltype.split(':::')` # it looks like 'GALAXY' , ' ' (e.g., for galaxies as galaxy templates don't have any subtype)

In archetype mode, the fulltype looks like: 'GALAXY:::ELG_105', 'GALAXY:::BGS_15' .. etc

Now, when fulltype is split in archetype mode as:
`spectype = [ el.split(':::')[0] for el in tmp['fulltype'] ]`; first this gives an error because `el` is a numpy array so can't be split so changing this to:
`spectype = [ el[0].split(':::')[0] for el in tmp['fulltype'] ]`, resolves this issue. 

Now when fulltype is saved in the table as:

`l = len(tmp['chi2'])` ## this is usually 3 (as by default redrock saves the first three minimas in details.h5 file

`tmp['spectype'] = np.array([spectype]*l).reshape((l, 1))`  

## this statement gives the reshape error as `spectype` is already a list with size 3, therefore it becomes a new array with size 9  and can not be reshaped in (3,1) array.

**Solution:**

Explicitly define the size of array to reshape correctly by a variable `nmin' which is 1 in case of archetypes and len(tmp['chi2']) in no-archetype mode.

**Tests:**

I ran `main `branch for 

 `rrdesi -i /global/cfs/cdirs/desi/users/abhijeet/visual_tiles/spectra/ELG/fuji-80606-coadd.fits --archetypes /global/homes/a/abhijeet/software/desisoft/redrock-archetypes/ --targetids 39627646572697743,39627652591519496 -o test.fits -d test.hd5`

I get the following error:
`spectype = [ el.split(':::')[0] for el in tmp['fulltype'] ]
AttributeError: 'numpy.ndarray' object has no attribute 'split'`

The new branch `fulltype_reshape` runs without any error.


