### PR TITLE
Added minwave and maxwave variables to templates.py that store wave[0]

### DIFF
--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -110,6 +110,8 @@ class Template(object):
 
         self._nbasis = self.flux.shape[0]
         self._nwave = self.flux.shape[1]
+        self.minwave = self.wave[0]
+        self.maxwave = self.wave[-1]
 
 
     @property


### PR DESCRIPTION
and wave[-1] respectively.  This is used in trapz_rebin to check bin edges against input wavelength range.  Change was made after we realized that after copying template.wave and template.flux to cupy arrays, accessing them to compare to scalar on the CPU was responsible for 40% of rebin time in fine redshift scan so this eliminates need to copy to and from GPU to CPU unnecessarily.

Modified trapz_rebin to accept these as optional arguments.

Modified transmission_Lyman for a slight speed gain to ignore lines that don't overlap with wavelength range.

These changes result in a speed gain of "Finding best redshift" from 16.8s to 12.5s with 64 CPU and 4 GPU on Perlmutter with environment 23.1 and templates 0.8.