### PR TITLE
Archetype mode Numba conflict when run on perlmutter

### DIFF
--- a/py/redrock/archetypes.py
+++ b/py/redrock/archetypes.py
@@ -34,7 +34,7 @@ class Archetype():
         h = fits.open(os.path.expandvars(filename), memmap=False)
 
         hdr = h['ARCHETYPES'].header
-        self.flux = np.asarray(h['ARCHETYPES'].data['ARCHETYPE'])
+        self.flux = np.asarray(h['ARCHETYPES'].data['ARCHETYPE']).astype('float64') # trapz_rebin only works with 'f8' arrays
         self._narch = self.flux.shape[0]
         self._nwave = self.flux.shape[1]
         self._rrtype = hdr['RRTYPE'].strip()


### PR DESCRIPTION
When `redrock` is run with archetypes on perlmutter the `trapz_rebin` gives error:
`numba.core.errors.NumbaValueError: Unsupported array dtype: >f4` if archetypes have single precision ('f4')

**Solution**
Just convert the data type of archetypes to `float64` explicitly in `archetypes.py' and it succeeds!