### PR TITLE
 Possible fix to issue #243 

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -685,7 +685,12 @@ def rrdesi(options=None, comm=None):
             if os.path.exists(args.archetypes):
                 print('Archetype file exists..\n')
             else:
-                raise IOError("ERROR: can't find archetypes_dir\n")
+                print("ERROR: can't find archetypes_dir\n")
+                sys.stdout.flush()
+                if comm is not None:
+                    comm.Abort()
+                else:
+                    sys.exit(1)
                 
     targetids = None
     if args.targetids is not None:

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -680,8 +680,13 @@ def rrdesi(options=None, comm=None):
                     comm.Abort()
                 else:
                     sys.exit(1)
-
-
+        
+        if args.archetypes is not None:
+            if os.path.exists(args.archetypes):
+                print('Archetype file exists..\n')
+            else:
+                raise IOError("ERROR: can't find archetypes_dir\n")
+                
     targetids = None
     if args.targetids is not None:
         targetids = [ int(x) for x in args.targetids.split(",") ]


### PR DESCRIPTION
Hi @sbailey 

Regarding [redrock/issue#243](https://github.com/desihub/redrock/issues/243)

I guess the reason this happens is that redrock looks for archetype files in the very last steps when it actually looks for the best archetypes for best-fit redshifts. Until then it doesn't actually look if the file exists.

I think this can be solved by checking the `args.archetypes` in the very beginning. If the archetypes are provided and it does not exist the rrdesi should just exit, otherwise continue.

I just created a pull request with the branch name `missing_archetypes` that solves this issue.

I re-ran the same script on `missing_archetypes` and it succeeds if the provided file exists and raise IOError if the file does not exist and exits.

`rrdesi --archetypes /does/not/exist  -i $CFS/desi/spectro/redux/fuji/tiles/cumulative/80606/20201219/coadd-0-80606-thru20201219.fits --targetids 39627646572697743,39627652591519496 -o test.fits -d test.hd5`

gives

`ERROR: can't find archetypes_dir`

But if the file exists: 

`rrdesi --archetypes/global/homes/a/abhijeet/software/desisoft/redrock-archetypes -i $CFS/desi/spectro/redux/fuji/tiles/cumulative/80606/20201219/coadd-0-80606-thru20201219.fits --targetids 39627646572697743,39627652591519496 -o test.fits -d test.hd5`

it succeeds!

While the `main` branch fails if run:

`rrdesi --archetypes /does/not/exist -i $CFS/desi/spectro/redux/fuji/tiles/cumulative/80606/20201219/coadd-0-80606-thru20201219.fits --targetids 39627646572697743,39627652591519496 -o test.fits -d test.hd5`

gives error:

```
--- Process 0 raised an exception ---
Proc 0: Traceback (most recent call last):
Proc 0:   File "/global/homes/a/abhijeet/software/desisoft/redrock/py/redrock/external/desi.py", line 805, in rrdesi
    scandata, zfit = zfind(targets, dtemplates, mpprocs,
Proc 0:   File "/global/homes/a/abhijeet/software/desisoft/redrock/py/redrock/zfind.py", line 414, in zfind
    spectype = [ el[0].split(':::')[0] for el in tmp['fulltype'] ] #el is a list with one element (corresponding to each minima)
Proc 0: KeyError: 'fulltype'

Traceback (most recent call last):
  File "/global/homes/a/abhijeet/software/desisoft/redrock/bin/rrdesi", line 10, in <module>
    desi.rrdesi(comm=None)
  File "/global/homes/a/abhijeet/software/desisoft/redrock/py/redrock/external/desi.py", line 886, in rrdesi
    raise err
  File "/global/homes/a/abhijeet/software/desisoft/redrock/py/redrock/external/desi.py", line 805, in rrdesi
    scandata, zfit = zfind(targets, dtemplates, mpprocs,
  File "/global/homes/a/abhijeet/software/desisoft/redrock/py/redrock/zfind.py", line 414, in zfind
    spectype = [ el[0].split(':::')[0] for el in tmp['fulltype'] ] #el is a list with one element (corresponding to each minima)
KeyError: 'fulltype'


```