### PR TITLE
Abhijeet per camera gpu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Or::
 
     git clone https://github.com/desihub/redrock-archetypes.git
 
-In summary, the archetypes method uses a combination of physical galaxy spectra and Legendre polynomials to construct a new set of templates and then solve for the coefficients using the bounded value least square method. The method solves for the coefficients of the Legendre polynomials in each camera (b, r, z cameras of desi, ``--per-camera`` keyword is introduced for that).
+In summary, the archetypes method uses a combination of physical galaxy spectra and Legendre polynomials to construct a new set of templates and then solve for the coefficients using the bounded value least square method for a few redshifts defined by ``--nminima``. The method solves for the coefficients of the Legendre polynomials in each camera (b, r, z cameras of desi, ``--per-camera`` keyword is introduced for that). Another argument is ``--prior_sigma``, which can be prescribed to add a prior while solving for the coefficients (e.g. ``--prior_sigma 0.1``). If ``-deg_legendre 0`` is provided, the method will only use archetypes to fit the spectra; no Legendre polynomials will be used.
 
 Example run::
     
@@ -65,9 +65,9 @@ Example run::
 
 **3) Archetypes + Nearest neighbours (in chi2 space) approach**::
 
-Similar to archetypes (method - 2), it also looks for the nearest neighbours of the best archetypes in chi2 space, selects a few nearest neighbours (input provided by the user, ``-n_nearest``) and then constructs a new set of templates combing these archetypes and Legendre polynomials to fit the galaxy spectra. 
+Similar to archetypes (method - 2), it also looks for the nearest neighbours of the best archetypes in chi2 space, selects a few nearest neighbours (input provided by the user, ``-n_nearest``) and then constructs a new set of templates combining these archetypes and Legendre polynomials to fit the galaxy spectra as described above. 
 
-Example run ::
+Example run::
         
     rrdesi -i <spectra_file> --archetypes <archetype_dir or archetype_file> -o <output_file> -d  <details_file.h5> -deg_legendre 2 -n_nearest 2 --per-camera
 

--- a/py/redrock/archetypes.py
+++ b/py/redrock/archetypes.py
@@ -204,7 +204,7 @@ class Archetype():
             nbasis = tdata[hs].shape[2]
         if per_camera:
             #Batch placeholder that right now loops over each arch but will be GPU accelerated
-            (zzchi2, zzcoeff) = per_camera_coeff_with_least_square_batch(spectra, tdata, nleg, method='bvls', n_nbh=1, use_gpu=use_gpu, prior=prior)
+            (zzchi2, zzcoeff) = per_camera_coeff_with_least_square_batch(spectra, tdata, nleg, method='bvls', n_nbh=n_nearest, use_gpu=use_gpu, prior=prior)
         else:
             #Use CPU mode for calc_zchi2 since small tdata
             (zzchi2, zzcoeff) = calc_zchi2_batch(spectra, tdata, weights, flux, wflux, 1, nbasis, use_gpu=False)

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -592,6 +592,9 @@ def rrdesi(options=None, comm=None):
 
     parser.add_argument("--nminima", type=int, default=3,
         required=False, help="the number of redshift minima to search")
+    
+    parser.add_argument("--prior_sigma", type=float, default=None,
+        required=False, help="sigma to add as prior in solving linear equation, 1/sig**2 will be added")
 
     parser.add_argument("--allspec", default=False, action="store_true",
         required=False, help="use individual spectra instead of coadd")
@@ -717,7 +720,8 @@ def rrdesi(options=None, comm=None):
                     print('No Legendre polynomial will be added to archetypes...\n')
                 if args.n_nearest:
                     print('n_nearest argument is provided so %d nearest neighbour (in chi2 space) to the best archetype will be used for further modeling...\n'%(args.n_nearest-1))
-                    
+                if args.prior_sigma:
+                    print('prior_sigma = %s has been provided, so a prior will be added while solving for the coefficients\n'%(args.prior_sigma))
             else:
                 print("ERROR: can't find archetypes_dir or it is unreadable\n")
                 sys.stdout.flush()
@@ -848,7 +852,7 @@ def rrdesi(options=None, comm=None):
 
         scandata, zfit = zfind(targets, dtemplates, mpprocs,
             nminima=args.nminima, archetypes=args.archetypes,
-            priors=args.priors, chi2_scan=args.chi2_scan, use_gpu=use_gpu, nz=args.nz, per_camera=args.per_camera, deg_legendre=args.deg_legendre, n_nearest=args.n_nearest)
+            priors=args.priors, chi2_scan=args.chi2_scan, use_gpu=use_gpu, nz=args.nz, per_camera=args.per_camera, deg_legendre=args.deg_legendre, n_nearest=args.n_nearest, prior_sigma=args.prior_sigma)
 
         stop = elapsed(start, "Computing redshifts", comm=comm)
 

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -536,7 +536,7 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
             allzfit.append(astropy.table.Table(tzfit))
 
         allzfit = astropy.table.vstack(allzfit)
-        print(allzfit['targetid', 'z', 'zwarn', 'chi2', 'deltachi2','spectype', 'subtype'])
+        #print(allzfit['targetid', 'z', 'zwarn', 'chi2', 'deltachi2','spectype', 'subtype'])
         #print(allzfit['targetid', 'z', 'zwarn', 'chi2', 'deltachi2','spectype'])
         # Cosmetic: move TARGETID to be first column as primary key
         try:

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -359,7 +359,7 @@ def per_camera_coeff_with_least_square_batch(spectra, tdata, nleg, narch, method
     ### PLACEHOLDER for algorithm that will be GPU accelerated
     ncam = 3 # number of cameras in DESI: b, r, z
     zzchi2 = np.zeros(narch, dtype=np.float64)
-    zzcoeff = np.zeros((narch,  1+ncam*(nleg)), dtype=np.float64)
+    zzcoeff = np.zeros((narch,  n_nbh+ncam*(nleg)), dtype=np.float64)
 
     tdata_one = dict()
     for i in range(narch):
@@ -367,7 +367,7 @@ def per_camera_coeff_with_least_square_batch(spectra, tdata, nleg, narch, method
             tdata_one[hs] = tdata[hs][i,:,:]
             if (use_gpu):
                 tdata_one[hs] = tdata_one[hs].get()
-        zzchi2[i], zzcoeff[i]= per_camera_coeff_with_least_square(spectra, tdata_one, nleg, method='bvls', n_nbh=1, prior=prior)
+        zzchi2[i], zzcoeff[i]= per_camera_coeff_with_least_square(spectra, tdata_one, nleg, method='bvls', n_nbh=n_nbh, prior=prior)
     return zzchi2, zzcoeff
 
 def batch_dot_product_sparse(spectra, tdata, nz, use_gpu):

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -303,10 +303,6 @@ def per_camera_coeff_with_least_square(spectra, tdata, nleg, method=None, n_nbh=
 
     nbasis = n_nbh+nleg*ncam # n_nbh : for actual physical archetype(s), nleg: number of legendre polynomials, ncamera: number of cameras
     
-    # in case of zero ivars
-    if weights.sum()==0:
-        return  9e+99, np.zeros(nbasis)
-
     #linear templates in each camera (only the Legendre terms will vary per camera, the lead archetype(s) will remain same for entire spectra)
 
     Tb = Tb_for_archetype(spectra, tdata, nbasis, n_nbh, nleg)  
@@ -335,6 +331,7 @@ def per_camera_coeff_with_least_square(spectra, tdata, nleg, method=None, n_nbh=
                 res = lsq_linear(M, y, bounds=bounds, method='bvls')
                 zcoeff = res.x
             else:
+                # in case of zero ivars
                 return 9e+99, np.zeros(nbasis)
         except np.linalg.LinAlgError:
             return 9e+99, np.zeros(nbasis)


### PR DESCRIPTION
Use batch rebin, transmission_Lyman, and calc_zchi2 operations.

Speed gains: without archetypes, redrock on 4 GPU / 4 CPU takes 14.8s
reported total run time, 7.3s of which is in the fine redshift scan.
Comparatively with 64 CPU and 0 GPU the base redrock runs in 40.0s
reported total run time with 6.7s spent in fine redshift scan.

Adding the base archetypes option (without per-camera or nearest
neighbor) raises CPU times to 63.8s overall and 28.1s in fine z scan so
about 60% increase overall and about 4x slower in fine z scan.

With the new code the "batch" CPU mode slightly improves this to 60.0s
and 24.2s.

With the new GPU code, it runs on 4 GPU / 4 CPU in 22.8s total and 14.3s
for fine z scan, a 50% overall increase but only 2x speed increase in
the fine z scan, a big improvement from CPU times.

Also updated transmission_Lyman to return None when given scalar z to
match behavior when given an array of redshifts, in the case where the
wavelength range is not affected by Lyman transmission.  There is no
need in this case to calculate an array of all ones and then
additionally multiply the rebinned data by it.

Have yet to update --per-camera and -n_nearest options so right now
there are placeholders so that it does not crash that simply loop over
the existing CPU-mode logic.  These will be updated shortly.