### PR TITLE
check for the template dimension so Redrock works on a single template

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ redrock Change Log
 0.18.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Check template dimension so code works on a single template (PR `#264`_). 
+
+.. _`#264`: https://github.com/desihub/redrock/pull/264
 
 0.18.0 (2023-09-14)
 -------------------

--- a/py/redrock/rebin.py
+++ b/py/redrock/rebin.py
@@ -123,7 +123,7 @@ def centers2edges(centers):
 # of this code have already been tested and shown to perform no better
 # than numba on Intel haswell and KNL architectures.
 
-@numba.jit
+@numba.jit(nopython=True)
 def _trapz_rebin_1d(x, y, edges, results):
     '''
     Numba-friendly version of trapezoidal rebinning
@@ -175,7 +175,7 @@ def _trapz_rebin_1d(x, y, edges, results):
 
     return
 
-@numba.jit
+@numba.jit(nopython=True)
 def _trapz_rebin_batch(x, y, edges, myz, results, redshifted_x):
     '''
     Numba-friendly version of trapezoidal rebinning

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -553,7 +553,11 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
             allzfit.replace_column('spectype',allzfit['spectype'].astype('<U6'))
 
         maxcoeff = np.max([t.template.nbasis for t in templates])
-        ntarg, ncoeff = allzfit['coeff'].shape
+        if allzfit['coeff'].ndim == 1:
+            ntarg = 1
+            ncoeff = allzfit['coeff'].shape
+        else:
+            ntarg, ncoeff = allzfit['coeff'].shape
         if ncoeff != maxcoeff:
             coeff = np.zeros((ntarg, maxcoeff), dtype=allzfit['coeff'].dtype)
             coeff[:,0:ncoeff] = allzfit['coeff']

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -554,8 +554,8 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
 
         maxcoeff = np.max([t.template.nbasis for t in templates])
         if allzfit['coeff'].ndim == 1:
-            ntarg = 1
-            ncoeff = allzfit['coeff'].shape
+            ntarg = allzfit['coeff'].shape
+            ncoeff = 1
         else:
             ntarg, ncoeff = allzfit['coeff'].shape
         if ncoeff != maxcoeff:


### PR DESCRIPTION
Trivial fix for #231 and tested (using this branch and `main` for everything else) with @araichoor's single template:
```
% export RR_TEMPLATE_DIR=/pscratch/sd/r/raichoor/rr-template
% ls -l $RR_TEMPLATE_DIR
-rw-rw---- 1 raichoor desi 930240 Feb  2  2023 rrtemplate-lae.fits
% bin/rrdesi -i $DESI_ROOT/spectro/redux/iron/healpix/main/backup/0/2/coadd-main-backup-2.fits \
  -o /pscratch/sd/r/raichoor/redrock.fits -d $PSCRATCH/rrdetails.h5
Running on a NERSC login node- reducing number of processes to 4
Running with 4 processes
Loading targets...
Read and distribution of 44 targets: 0.3 seconds
DEBUG: Read templates from /pscratch/sd/r/raichoor/rr-template
DEBUG: Using redshift range 2.1000-2.7963 for rrtemplate-lae.fits
Read and broadcast of 1 templates: 0.0 seconds
Creating GPU context: 0.0 seconds
Rebinning templates: 0.7 seconds
Computing redshifts
  Scanning redshifts for template LAE
    Progress:   0 %
[snip]
    Progress: 100 %
    Finished in: 2.4 seconds
Scanning redshifts: 2.4 seconds
  Finding best fits for template LAE
    Finished in: 0.6 seconds
Finding best redshift: 0.6 seconds
Finalizing results: 0.1 seconds
Computing redshifts: 3.1 seconds
Writing zscan data took: 0.1 seconds
Writing /pscratch/sd/i/ioannis/redrock.fits took: 0.1 seconds
Total run time: 4.3 seconds
```

I looked into improving unit tests to cover this kind of case, but the coverage of using different kinds of templates is not great at the moment, and it's not something I'm willing to tackle (sorry). 