### PR TITLE
adjust coeff size for legendre only for archetypes

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -851,9 +851,9 @@ def rrdesi(options=None, comm=None):
         dwave = targets.wavegrids()
         
         ncamera = len(list(dwave.keys())) # number of cameras for given instrument
-        if args.archetypes_no_legendre:
+        if args.archetypes_no_legendre or args.archetypes is None:
             if comm_rank == 0:
-                print('--archetypes-no-legendre argument is provided, will turn off all the Legendre related arguments')
+                print('no archetypes or --archetypes-no-legendre; will turn off all the Legendre related arguments')
             archetype_legendre_prior = None
             archetype_legendre_degree =0
             archetype_legendre_percamera = False

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -595,7 +595,7 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
         if allzfit['spectype'].dtype != '<U6':
             allzfit.replace_column('spectype',allzfit['spectype'].astype('<U6'))
 
-        if not per_camera:
+        if archetypes is None or not per_camera:
             maxcoeff = np.max([t.template.nbasis for t in templates])
         else:
             if n_nearest is not None:


### PR DESCRIPTION
This PR is a followup to #255 (archetypes), fixing a bug where deg_legendre was being used to adjust the size of the COEFF array even if archetypes were not being used and thus no legendre polynomials either.

I didn't catch this while testing PR #255 because I had been using galaxy templates with ncoeff=10, which was greater than ncamera*deg_legendre+1 = 3*2+1 = 7, and so the coeffs arrays remained size 10.  However, when running the full pipeline, the QSOQN afterburner re-runs Redrock with only the quasar templates with ncoeff=4.  Redrock was incorrectly padding this upward to 7 coefficients, which confused the afterburner expecting only 4.

@abhi0395 can you double check this?  We need to get a fix in place before observations tonight.  Thanks.