### PR TITLE
updated docstring readthedocs

### DIFF
--- a/py/redrock/archetypes.py
+++ b/py/redrock/archetypes.py
@@ -163,33 +163,29 @@ class Archetype():
     
     def nearest_neighbour_model(self, target,weights,flux,wflux,dwave,z, n_nearest, zzchi2, trans, per_camera, dedges=None, binned=None, use_gpu=False, prior=None, ncam=None):
         
-        """
+        """Nearest neighbour archetype approach; fitting with a combinating of nearest archetypes in chi2 space
         
-        Parameters:
-        ------------------
-        target (Target): the target object that contains spectra
-        weights (array): concatenated spectral weights (ivar).
-        flux (array): concatenated flux values.
-        wflux (array): concatenated weighted flux values.
-        dwave (dict): dictionary of wavelength grids
-        z (float): best redshift
-        n_nearest (int): number of nearest neighbours to be used in chi2 space (including best archetype)
-        zchi2 (array); chi2 array for all archetypes
-        trans (dict); dictionary of transmission Ly-a arrays
-        per_camera (bool): If True model will be solved in each camera
-        dedges (dict): in GPU mode, use pre-computed dict of wavelength bin edges, already on GPU
-        binned (dict): already computed dictionary of rebinned fluxes
-        use_gpu (bool): use GPU or not
-        prior (2d array): prior matrix on coefficients (1/sig**2)
-        ncam (int): Number of camera for given Instrument
-
+        Args:
+            target (Target): the target object that contains spectra
+            weights (array): concatenated spectral weights (ivar).
+            flux (array): concatenated flux values.
+            wflux (array): concatenated weighted flux values.
+            dwave (dict): dictionary of wavelength grids
+            z (float): best redshift
+            n_nearest (int): number of nearest neighbours to be used in chi2 space (including best archetype)
+            zchi2 (array); chi2 array for all archetypes
+            trans (dict); dictionary of transmission Ly-a arrays
+            per_camera (bool): If True model will be solved in each camera
+            dedges (dict): in GPU mode, use pre-computed dict of wavelength bin edges, already on GPU
+            binned (dict): already computed dictionary of rebinned fluxes
+            use_gpu (bool): use GPU or not
+            prior (2d array): prior matrix on coefficients (1/sig**2)
+            ncam (int): Number of camera for given Instrument
         
         Returns:
-        -----------------
-
-        chi2 (float): chi2 of best fit model
-        zcoeff (array): zcoeff of best fit model
-        fulltype (str): fulltype of best archetypes
+            chi2 (float): chi2 of best fit model
+            zcoeff (array): zcoeff of best fit model
+            fulltype (str): fulltype of best archetypes
 
         """
 

--- a/py/redrock/fitz.py
+++ b/py/redrock/fitz.py
@@ -149,6 +149,8 @@ def fitz(zchi2, redshifts, target, template, nminima=3, archetype=None, use_gpu=
             of Spectrum objects at different wavelength grids.
         template (Template): the template for this fit.
         nminima (int): the number of minima to consider.
+        archetype (object, optional): A single Archetype object (of given spectype)
+            to use for final fitz choice of best chi2 vs. z minimum.
         use_gpu (bool): use GPU or not
         deg_legendre (int): in archetype mode polynomials upto deg_legendre-1 will be used
         zminfit_npoints (int): number of finer redshift pixels to search for final redshift - default 15

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -239,31 +239,29 @@ def calc_zchi2_one(spectra, weights, flux, wflux, tdata):
     return zchi2, zcoeff
 
 def per_camera_coeff_with_least_square_batch(target, tdata, weights, flux, wflux, nleg, narch, method=None, n_nbh=None, prior=None, use_gpu=False, ncam=None):
-    """
-    This function calculates coefficients for archetype mode in each camera using normal linear algebra matrix solver or BVLS (bounded value least square) method
+    
+    """This function calculates coefficients for archetype mode in each camera using normal linear algebra matrix solver or BVLS (bounded value least square) method
 
     BVLS described in : https://www.stat.berkeley.edu/~stark/Preprints/bvls.pdf
 
     Scipy: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.lsq_linear.html
 
-    Parameters
-    ---------------------
-
-    target (object): target object
-    tdata (dict): template data for model fit for ALL archetypes
-    weights (array): concatenated spectral weights (ivar).
-    flux (array): concatenated flux values.
-    wflux (array): concatenated weighted flux values.
-    nleg (int): number of Legendre polynomials
-    narch (int): number of archetypes
-    method (string): 'PCA' or 'bvls' or 'nnls'
-    n_nbh (int): number of nearest best archetypes
-    prior (2d matrix); prior added to be the final solution step (1/sigma^2)
-    use_gpu (bool): use GPU or not
-    ncam (int): number of cameras for given instrument
-    Returns
-    --------------------
-    coefficients and chi2
+    Args:
+        target (object): target object
+        tdata (dict): template data for model fit for ALL archetypes
+        weights (array): concatenated spectral weights (ivar).
+        flux (array): concatenated flux values.
+        wflux (array): concatenated weighted flux values.
+        nleg (int): number of Legendre polynomials
+        narch (int): number of archetypes
+        method (string): 'PCA' or 'bvls' or 'nnls'
+        n_nbh (int): number of nearest best archetypes
+        prior (2d matrix); prior added to be the final solution step (1/sigma^2)
+        use_gpu (bool): use GPU or not
+        ncam (int): number of cameras for given instrument
+    
+    Returns:
+        coefficients and chi2
 
     """
 

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -256,7 +256,7 @@ def per_camera_coeff_with_least_square_batch(target, tdata, weights, flux, wflux
         narch (int): number of archetypes
         method (string): 'PCA' or 'bvls' or 'nnls'
         n_nbh (int): number of nearest best archetypes
-        prior (2d matrix); prior added to be the final solution step (1/sigma^2)
+        prior (array): prior matrix added to the Legendre coefficients (1/sigma^2)
         use_gpu (bool): use GPU or not
         ncam (int): number of cameras for given instrument
     


### PR DESCRIPTION
I just realized that the docstrings for certain functions were not formatted correctly, leading to unclean description on [https://redrock.readthedocs.io/en/latest/api.html](https://chat.openai.com/c/url). I have modified the docstrings for the following functions to ensure proper formatting.

`archetypes.nearest_neighbour_model()`
`zscan.per_camera_coeff_with_least_square_batch()`