### PR TITLE
--archetype_nnearest crashing on main branch

### DIFF
--- a/py/redrock/archetypes.py
+++ b/py/redrock/archetypes.py
@@ -307,10 +307,11 @@ class Archetype():
         
         ## Prior must be redefined to remove nearest neighbour approach, 
         # because prior was defined based on n_nearest argument..
-        # this is needed because the first fitting is done with just one archetype
+        # this logic is needed because the first fitting is done with just one archetype 
+        #and then nearest neighbour approach is implemented
         if n_nearest is not None:
-            nnearest_prior = prior.copy()
-            prior = prior[n_nearest-1:,][:,n_nearest-1:] # just remove first few rows corresponding to the nearest_archetypes
+            nnearest_prior = prior.copy() # prior corresponding to nearest_nbh method
+            prior = prior[n_nearest-1:,][:,n_nearest-1:] # removing first rows/columns corresponding to the nearest_archetypes, and keeping just one row for one archetype
 
         for hs, wave in dwave.items():
             if (trans[hs] is not None):

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -879,7 +879,10 @@ def rrdesi(options=None, comm=None):
             archetype_legendre_prior = args.archetype_legendre_prior
             if comm_rank == 0 and args.archetypes is not None:
                 print('archetype_legendre_prior = %s has been provided, so a prior will be added while solving for the coefficients'%(archetype_legendre_prior))
-             
+            if args.archetype_nnearest is not None:
+                if comm_rank == 0 and args.archetypes is not None:
+                    print('nearest neighbour = %d is provided, will do the final fitting for N-best nearest archetypes in chi2 space..'%(args.archetype_nnearest))
+        
         stop = elapsed(start, "Read and distribution of {} targets"\
             .format(len(targets.all_target_ids)), comm=comm)
 

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -312,6 +312,7 @@ def per_camera_coeff_with_least_square_batch(target, tdata, weights, flux, wflux
 
     # saving leading archetype coefficients in correct order
     ret_zcoeff['alpha'] = [zzcoeff[:,k] for k in range(n_nbh)] # archetype coefficient(s)
+    # logic in case nearest neighbour is used
     if n_nbh>1:
         ret_zcoeff['alpha'] = np.array([ret_zcoeff['alpha'][jj][0] for jj in range(n_nbh)])[None,:]
     else:

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -312,8 +312,10 @@ def per_camera_coeff_with_least_square_batch(target, tdata, weights, flux, wflux
 
     # saving leading archetype coefficients in correct order
     ret_zcoeff['alpha'] = [zzcoeff[:,k] for k in range(n_nbh)] # archetype coefficient(s)
-    ret_zcoeff['alpha'] = ret_zcoeff['alpha'][0][:,None]
-
+    if n_nbh>1:
+        ret_zcoeff['alpha'] = np.array([ret_zcoeff['alpha'][jj][0] for jj in range(n_nbh)])[None,:]
+    else:
+        ret_zcoeff['alpha'] = ret_zcoeff['alpha'][0][:,None]
     if nleg>=1:
         split_coeff =  np.split(zzcoeff[:,n_nbh:], ncam, axis=1) # n_camera = 3
         # In target spectra redrock saves values as 'b', 'z', 'r'.
@@ -322,7 +324,6 @@ def per_camera_coeff_with_least_square_batch(target, tdata, weights, flux, wflux
 
         for band in ['b', 'r', 'z']:# 3 cameras
             ret_zcoeff[band] = old_coeff[band]
-
     coeff = np.concatenate(list(ret_zcoeff.values()), axis=1)
     #print(f'{time.time()-start} [sec] took for per camera BVLS method\n')
     return zzchi2, coeff

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -627,6 +627,7 @@ def calc_zchi2_batch(spectra, tdata, weights, flux, wflux, nz, nbasis, solve_mat
         use_gpu (bool): use GPU or not
         fullprecision (bool): Whether or not to ensure reproducibly identical
             results.  See calc_batch_dot_product_3d3d_gpu.
+        prior (2d array): prior matrix on coefficients (1/sig**2)     
 
     Returns:
         zchi2 (array): array with one element per redshift for this target


### PR DESCRIPTION
When running `rrdesi` in archetype mode with `--archetype-nnearest` argument, it fails citing array mismatch error:

`srun -n 32 -c 4 rrdesi_mpi -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/10752/20240117/coadd-2-10752-thru20240117.fits -o archetype-test-2-10752-thru20240117_1.fits -d details.h5 --archetypes /global/homes/a/abhijeet/software/desisoft/new-archetypes/rrarchetype-galaxy.fits --archetype-nnearest 3`

**Error:**

```
Proc 3:   File "/global/homes/a/abhijeet/software/desisoft/redrock/py/redrock/zscan.py", line 311, in per_camera_coeff_with_least_square_batch
    zzchi2[j], zzcoeff[j] = calc_zchi2_batch(spectra, tdata2, weights, flux, wflux, 1, nbasis, solve_matrices_algorithm=method.upper(), solver_args=solver_args, prior=prior, use_gpu=use_gpu)
Proc 3:   File "/global/homes/a/abhijeet/software/desisoft/redrock/py/redrock/zscan.py", line 739, in calc_zchi2_batch
    M += prior
Proc 3: ValueError: operands could not be broadcast together with shapes (7,7) (9,9) (7,7) 
```

**Explanation and solution** 

The key point is that the archetype method first solves the matrix for each archetype in the loop and selects the nearest (N-best) neighbors based on the final chi2 array and then solves again, including those nearest archetypes. The error comes because the prior matrix is defined based on the `--archetype-nearest` argument at the start of the algorithm, which is larger than expected when it solves the linear equation for the single archetype. 

I have now corrected the logic in case  `--archetype-nnearest` is ever used in archetype mode in `archetypes.get_best_archetype`. I also made necessary changes in  `archetypes.nearest_neighbour_model`  and `zscan.per_camera_coeff_with_least_square_batch` to correct this issue. Additionally, I have added a print statement in `desi.py` to print the statement for clarity in case `--archetype-nnearest` is used.

**Test run**

Running rrdesi from new branch `abhijeet_archetypes_nnearest` succeeds without any error:

`srun -n 32 -c 4 rrdesi_mpi -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/10752/20240117/coadd-2-10752-thru20240117.fits -o /global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_nnearest/archetype_nearest_nbh-test-2-10752-thru20240117.fits -d details.h5 --archetypes /global/homes/a/abhijeet/software/desisoft/new-archetypes/rrarchetype-galaxy.fits --archetype-nnearest 3`

**Sanity checks**

On new branch I ran with and without archetype (NO `--archetype-nnearest` was used) and checked the outputs from `main` branch.

1) `abhijeet_archetypes_nnearest` branch::

Without archetype: 
`/global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_nnearest/no_archetype-test-2-10752-thru20240117.fits`

With archetype (no nearest neighbours):
`/global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_nnearest/archetype_no_nearest_nbh-test-2-10752-thru20240117.fits`

2) `main` branch::

Without archetype: 
`/global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/main/no_archetype-test-2-10752-thru20240117.fits`

With archetype (no nearest neighbours):
`/global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/main/archetype-test-2-10752-thru20240117.fits`

I compared these output files with each other, and the answers did not change.

**Checks:**

```
ref_file1 = '/global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/main/no_archetype-test-2-10752-thru20240117.fits'
ref_file2='/global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_nnearest/no_archetype-test-2-10752-thru20240117.fits'
tt1 = Table.read(ref_file1, hdu=1)
tt2 = Table.read(ref_file2, hdu=1)
np.allclose(tt1['Z'], tt2['Z'])
np.count_nonzero(tt1['Z']-tt2['Z']) 
```

```
ref_file1 = '/global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/main/archetype-test-2-10752-thru20240117.fits'
ref_file2='/global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_nnearest/archetype_no_nearest_nbh-test-2-10752-thru20240117.fits'
tt1 = Table.read(ref_file1, hdu=1)
tt2 = Table.read(ref_file2, hdu=1)
np.allclose(tt1['Z'], tt2['Z'])
np.count_nonzero(tt1['Z']-tt2['Z']) 
```

