### PR TITLE
Archetype failure due to key error in trans dict and failure in deg-leg 0 case

### DIFF
--- a/py/redrock/fitz.py
+++ b/py/redrock/fitz.py
@@ -256,7 +256,8 @@ def fitz(zchi2, redshifts, target, template, nminima=3, archetype=None, use_gpu=
         i = min(max(np.argmin(zzchi2),1), len(zz)-2)
         zmin, sigma, chi2min, zwarn = minfit(zz[i-1:i+2], zzchi2[i-1:i+2])
 
-        trans = dict()
+        #trans = dict()
+        trans = { hs:None for hs, w in dwave.items() } #define trans with keys and None values
         try:
             #Calculate xmin and xmax from template and pass as scalars 
             xmin = template.minwave*(1+zmin)

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -270,8 +270,11 @@ def per_camera_coeff_with_least_square_batch(target, tdata, weights, flux, wflux
     spectra = target.spectra
 
     nbasis = n_nbh+nleg*ncam # n_nbh : for actual physical archetype(s), nleg: number of legendre polynomials, ncamera: number of cameras
-    ret_zcoeff= {'alpha':[], 'b':[], 'r':[], 'z':[]}
-
+    
+    if nleg>0:
+        ret_zcoeff= {'alpha':[], 'b':[], 'r':[], 'z':[]}
+    else:
+        ret_zcoeff= {'alpha':[]} # in case no Legendre polynomials are used at all, only archetypes.
     #Setup dict of solver args to pass bounds to solver
     method = method.upper()
     solver_args = dict()


### PR DESCRIPTION
This pull request solves two separate issues on the `main` branch.

1) For some targetids the archetype mode fails citing `keyerror` in the trans dictionary.
2) The main branch fails if we want to run the archetype method without Legendre polynomials.

Example run for case (1) on `main' branch: 

`rrdesi -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/6786/20240117/coadd-4-6786-thru20240117.fits -o arch_test-39628278872412904.fits -d arch_39628278872412904.h5 --archetypes /global/homes/a/abhijeet/software/desisoft/new-archetypes/rrarchetype-galaxy.fits --targetids 39628278872412904`

fails citing following error:

```
MP calc_zchi2: Traceback (most recent call last):
MP calc_zchi2:   File "/global/homes/a/abhijeet/software/desisoft/redrock/py/redrock/zfind.py", line 90, in _mp_fitz
    zfit = fitz(chi2[i], t.template.redshifts, tg,
MP calc_zchi2:   File "/global/homes/a/abhijeet/software/desisoft/redrock/py/redrock/fitz.py", line 338, in fitz
    chi2min, coeff, fulltype = archetype.get_best_archetype(target,weights,flux,wflux,dwave,zbest, per_camera, n_nearest, trans=trans, use_gpu=use_gpu, prior=prior)
MP calc_zchi2:   File "/global/homes/a/abhijeet/software/desisoft/redrock/py/redrock/archetypes.py", line 321, in get_best_archetype
    if (trans[hs] is not None):
MP calc_zchi2: KeyError: -5909694164499214244
```

But when run on `archetype_leg0_and_trans_fix`, it succeeds.

Example run for case (2):

`rrdesi -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/11472/20240116/coadd-0-11472-thru20240116.fits -o /global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_leg0_and_trans_fix/redrock_test-39628128854739056.fits -d /global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_leg0_and_trans_fix/redrock_39628128854739056.h5 --targetids 39628128854739056 --archetypes /global/homes/a/abhijeet/software/desisoft/new-archetypes/rrarchetype-galaxy.fits`

fails on `main' branch:

```
MP calc_zchi2:   File "/global/homes/a/abhijeet/software/desisoft/redrock/py/redrock/archetypes.py", line 334, in get_best_archetype
    (zzchi2, zzcoeff) = per_camera_coeff_with_least_square_batch(target, tdata, weights, flux, wflux, nleg, self._narch, method=solve_method, n_nbh=1, prior=prior, use_gpu=use_gpu, ncam=ncam)
MP calc_zchi2:   File "/global/homes/a/abhijeet/software/desisoft/redrock/py/redrock/zscan.py", line 329, in per_camera_coeff_with_least_square_batch
    coeff = np.concatenate(list(ret_zcoeff.values()), axis=1)
MP calc_zchi2:   File "<__array_function__ internals>", line 180, in concatenate
MP calc_zchi2: ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 2 dimension(s) and the array at index 1 has 1 dimension(s)
```

But succeeds on `archetype_leg0_and_trans_fix` branch.

**Sanity checks**

Comparing results from main and this branch:

**-  Archetype mode (main):**

`srun -n 4 -c 4 --gpu-bind=map_gpu:3,2,1,0 rrdesi_mpi --gpu --max-gpuprocs 4 -i rrdesi_mpi -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/11472/20240116/coadd-0-11472-thru20240116.fits  -o /global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/main/arch_redrock-0-11472-thru20240116.fits -d /global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/main/arch_redrock-0-11472-thru20240116.fits --archetypes /global/homes/a/abhijeet/software/desisoft/new-archetypes/rrarchetype-galaxy.fits`

**-  Archetype mode (this branch):**

`srun -n 4 -c 4 --gpu-bind=map_gpu:3,2,1,0 rrdesi_mpi --gpu --max-gpuprocs 4 -i rrdesi_mpi -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/11472/20240116/coadd-0-11472-thru20240116.fits  -o /global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_leg0_and_trans_fix/arch_redrock-0-11472-thru20240116.fits -d /global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_leg0_and_trans_fix/arch_redrock-0-11472-thru20240116.fits --archetypes /global/homes/a/abhijeet/software/desisoft/new-archetypes/rrarchetype-galaxy.fits`

**- Comparison:**

```
file1 = f'/global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/main/arch_redrock-0-11472-thru20240116.fits'
file2 = f'/global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_leg0_and_trans_fix/arch_redrock-0-11472-thru20240116.fits'
tt1 = Table.read(file1, hdu=1)
tt2 = Table.read(file2, hdu=1)
np.count_nonzero(tt1['Z']-tt2['Z']
```

**-  Non archteype mode (main):**

`srun -n 4 -c 4 --gpu-bind=map_gpu:3,2,1,0 rrdesi_mpi --gpu --max-gpuprocs 4 -i rrdesi_mpi -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/11472/20240116/coadd-0-11472-thru20240116.fits  -o /global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/main/redrock-0-11472-thru20240116.fits -d /global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/main/redrock-0-11472-thru20240116.fits`

**- Non archetype mode (this branch):**

`srun -n 4 -c 4 --gpu-bind=map_gpu:3,2,1,0 rrdesi_mpi --gpu --max-gpuprocs 4 -i rrdesi_mpi -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/11472/20240116/coadd-0-11472-thru20240116.fits  -o /global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_leg0_and_trans_fix/redrock-0-11472-thru20240116.fits -d /global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_leg0_and_trans_fix/redrock-0-11472-thru20240116.h5 `

```
file1 = f'/global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/main/redrock-0-11472-thru20240116.fits'
file2 = f'/global/cfs/cdirs/desi/users/abhijeet/test_archetype_runs/archetype_leg0_and_trans_fix/redrock-0-11472-thru20240116.fits'
tt1 = Table.read(file1, hdu=1)
tt2 = Table.read(file2, hdu=1)
np.count_nonzero(tt1['Z']-tt2['Z'])
```

