### PR TITLE
add --negflux-nsig option to mask significantly negative flux

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -467,7 +467,7 @@ class DistTargetsDESI(DistTargets):
                             # mask significantly negative data (set ivar to 0)
                             sigma = self._my_data[toff].spectra[tspec_ivar[t]].flux * \
                                     np.sqrt(self._my_data[toff].spectra[tspec_ivar[t]].ivar)
-                            bignegflux = (sigma<-negflux_nsig)
+                            bignegflux = (sigma<-abs(negflux_nsig))
                             self._my_data[toff].spectra[tspec_ivar[t]].ivar[bignegflux] = 0.0
 
                             tspec_ivar[t] += 1
@@ -848,7 +848,7 @@ def rrdesi(options=None, comm=None):
         targets = DistTargetsDESI(args.infiles, coadd=(not args.allspec),
                                   targetids=targetids, first_target=first_target, n_target=n_target,
                                   comm=comm, cache_Rcsr=True, cosmics_nsig=args.cosmics_nsig,
-                                  negflux_nsig=args.negflux_nsig,
+                                  negflux_nsig=abs(args.negflux_nsig),
                                   capacities=capacities)
 
         #- Mask some problematic sky lines


### PR DESCRIPTION
@moustakas this PR adds an rrdesi --negflux-nsig option (default 5) to mask significantly negative data.

There is still some ongoing discussion about the case of sky mis-subtraction positive-negative fluctuations — masking only the negative here risks leaving positive peaks behind to fit false emission lines.  So lets *not* merge this yet, but this provides a branch to test and a place for comments.

Default rrdesi/rrdesi_mpi usage is unchanged, and it will apply a mask on 5-sigma negative flux pixels.  That threshold can be changed with `--negflux-nsig` (specify a positive number of sigma, the threshold will be applied to negative flux).  Having written that, I could probably make this safer by adding an abs or something to prevent sign misunderstandings leading to masking positive data...