### PR TITLE
Legendre nnls

### DIFF
--- a/py/redrock/archetypes.py
+++ b/py/redrock/archetypes.py
@@ -299,9 +299,7 @@ class Archetype():
 
         obs_wave = np.concatenate([dwave[key] for key in new_keys])
         
-        nleg = legendre[list(legendre.keys())[0]].shape[0]
-        #zzchi2 = np.zeros(self._narch, dtype=np.float64)
-        #zzcoeff = np.zeros((self._narch,  1+ncam*(nleg)), dtype=np.float64)
+        #nleg = legendre[list(legendre.keys())[0]].shape[0]
         
         #TODO: return best fit model as well
         #zzmodel = np.zeros((self._narch, obs_wave.size), dtype=np.float64)
@@ -343,10 +341,11 @@ class Archetype():
                 tdata[hs] = binned[hs].transpose()[:,:,None]
             nbasis = tdata[hs].shape[2]
         if per_camera:
+            #Hard code NNLS as solve method for per_camera_coeff_with_least_square_batch
             if (use_gpu):
-                (zzchi2, zzcoeff) = per_camera_coeff_with_least_square_batch(target, tdata, gpuweights, gpuflux, gpuwflux, tot_nleg, self._narch, method=solve_method, n_nbh=1, prior=prior, use_gpu=use_gpu, ncam=ncam)
+                (zzchi2, zzcoeff) = per_camera_coeff_with_least_square_batch(target, tdata, gpuweights, gpuflux, gpuwflux, tot_nleg, self._narch, method='NNLS', n_nbh=1, prior=prior, use_gpu=use_gpu, ncam=ncam)
             else:
-                (zzchi2, zzcoeff) = per_camera_coeff_with_least_square_batch(target, tdata, weights, flux, wflux, tot_nleg, self._narch, method=solve_method, n_nbh=1, prior=prior, use_gpu=use_gpu, ncam=ncam)
+                (zzchi2, zzcoeff) = per_camera_coeff_with_least_square_batch(target, tdata, weights, flux, wflux, tot_nleg, self._narch, method='NNLS', n_nbh=1, prior=prior, use_gpu=use_gpu, ncam=ncam)
         else:
             if (use_gpu):
                 (zzchi2, zzcoeff) = calc_zchi2_batch(spectra, tdata, gpuweights, gpuflux, gpuwflux, self._narch, nbasis, use_gpu=use_gpu)

--- a/py/redrock/fitz.py
+++ b/py/redrock/fitz.py
@@ -292,6 +292,8 @@ def fitz(zchi2, redshifts, target, template, nminima=3, archetype=None, use_gpu=
                 coeff = np.zeros(template.nbasis)
                 zwarn |= ZW.Z_FITLIMIT
                 zwarn |= ZW.BAD_MINFIT
+                #Set trans to None so as not to pass an empty dict to archetypes! CW 2/26/24
+                trans = None
             else:
                 #- Unknown problem; re-raise error
                 raise err
@@ -329,10 +331,13 @@ def fitz(zchi2, redshifts, target, template, nminima=3, archetype=None, use_gpu=
                     ncamera = len(list(dwave.keys())) # number of cameras, for e.g. DESI has three cameras
                 else:
                     ncamera = 1
+                tot_deg_legendre = deg_legendre
+                if archetype._solver_method == 'bvls':
+                    tot_deg_legendre = deg_legendre*2
                 if n_nearest is None:
-                    prior = prior_on_coeffs(1, deg_legendre, prior_sigma, ncamera)
+                    prior = prior_on_coeffs(1, tot_deg_legendre, prior_sigma, ncamera)
                 else:
-                    prior = prior_on_coeffs(n_nearest, deg_legendre, prior_sigma, ncamera)
+                    prior = prior_on_coeffs(n_nearest, tot_deg_legendre, prior_sigma, ncamera)
             else:
                 prior=None
             chi2min, coeff, fulltype = archetype.get_best_archetype(target,weights,flux,wflux,dwave,zbest, per_camera, n_nearest, trans=trans, use_gpu=use_gpu, prior=prior)

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -598,10 +598,13 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
         if archetypes is None or not per_camera:
             maxcoeff = np.max([t.template.nbasis for t in templates])
         else:
+            tot_deg_legendre = deg_legendre
+            if archetype._solver_method == 'bvls':
+                tot_deg_legendre = deg_legendre*2
             if n_nearest is not None:
-                maxcoeff = max(np.max([t.template.nbasis for t in templates]), ncamera*(deg_legendre)+n_nearest)
+                maxcoeff = max(np.max([t.template.nbasis for t in templates]), ncamera*(tot_deg_legendre)+n_nearest)
             else:
-                maxcoeff = max(np.max([t.template.nbasis for t in templates]), ncamera*(deg_legendre)+1)
+                maxcoeff = max(np.max([t.template.nbasis for t in templates]), ncamera*(tot_deg_legendre)+1)
 
         if allzfit['coeff'].ndim == 1:
             ntarg = allzfit['coeff'].shape

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -270,6 +270,7 @@ def per_camera_coeff_with_least_square_batch(target, tdata, weights, flux, wflux
     spectra = target.spectra
 
     nbasis = n_nbh+nleg*ncam # n_nbh : for actual physical archetype(s), nleg: number of legendre polynomials, ncamera: number of cameras
+    #nleg should be doubled already here if using BVLS so nbasis should be correct
     ret_zcoeff= {'alpha':[], 'b':[], 'r':[], 'z':[]}
 
     #Setup dict of solver args to pass bounds to solver
@@ -277,10 +278,12 @@ def per_camera_coeff_with_least_square_batch(target, tdata, weights, flux, wflux
     solver_args = dict()
     if (method == 'BVLS'):
         #only positive coefficients are allowed for the archetypes
-        bounds = np.zeros((2, nbasis))
-        bounds[0][n_nbh:]=-np.inf #constant and slope terms in archetype method (can be positive or negative)
-        bounds[1] = np.inf
-        solver_args['bounds'] = bounds
+        #bounds = np.zeros((2, nbasis))
+        #bounds[0][n_nbh:]=-np.inf #constant and slope terms in archetype method (can be positive or negative)
+        #bounds[1] = np.inf
+        #solver_args['bounds'] = bounds
+        #Update solver method
+        method = 'NNLS'
 
     #Use branching options because GPU is faster in batch in 3d
     #but due to timing weirdness in numpy, CPU is faster looping over

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -278,12 +278,10 @@ def per_camera_coeff_with_least_square_batch(target, tdata, weights, flux, wflux
     solver_args = dict()
     if (method == 'BVLS'):
         #only positive coefficients are allowed for the archetypes
-        #bounds = np.zeros((2, nbasis))
-        #bounds[0][n_nbh:]=-np.inf #constant and slope terms in archetype method (can be positive or negative)
-        #bounds[1] = np.inf
-        #solver_args['bounds'] = bounds
-        #Update solver method
-        method = 'NNLS'
+        bounds = np.zeros((2, nbasis))
+        bounds[0][n_nbh:]=-np.inf #constant and slope terms in archetype method (can be positive or negative)
+        bounds[1] = np.inf
+        solver_args['bounds'] = bounds
 
     #Use branching options because GPU is faster in batch in 3d
     #but due to timing weirdness in numpy, CPU is faster looping over


### PR DESCRIPTION
Non-negative least squares (NNLS) is significantly faster than the general case bounded value least squares (BVLS).  For archetypes, BVLS had been used where the archetype term had a bounded solution from 0 to inf and all of the legendre term solutions were allowed to float.  By adding additional terms to our basis vector that are the inverse of each legendre term, we are able to use NNLS instead, e.g., we have negative copies, v3 = -v1 and v4 = -v2 so that in our solution we could have c1 > 0, c3 = 0 for a positive result and the opposite for a negative.

This also required a modification to the prior array which was added to the `M` vector.  The results using NNLS now agree to within np.allclose to the original BVLS solution, with a significant speed gain.  The `Finding best redshift` section takes 45s on 4 GPU + 4 CPU versus 99s using BVLS.  However this only applies to when using GPUs.

When using 64 CPUs, additional negative legendre terms + NNLS are 113s for this section versus 74s for BVLS.  This is because the computation time for various array operations such as dot products on the larger arrays with the added terms overwhelms the speed gains from NNLS vs BVLS and thus when using CPU mode, we do NOT use the NNLS method and maintain the original BVLS.