### PR TITLE
add load_templates_from_header

### DIFF
--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -270,7 +270,7 @@ def find_templates(template_path=None):
         if not os.path.exists(template_path):
             raise ValueError(f'Missing {template_path=}')
         default_templates_file = template_path
-        template_dir = os.path.dirname(template_path)
+        template_dir = os.path.dirname(os.path.abspath(template_path))
     elif template_path.endswith( ('.fits', '.fits.gz', '.fits.fz') ):
         #- single template file, return that as a list
         return [template_path,]

--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -104,13 +104,13 @@ class Template(object):
                         "template type {}".format(self._rrtype))
                 zmin = self._redshifts[0]
                 zmax = self._redshifts[-1]
-                print("DEBUG: Using default redshift range {:.4f}-{:.4f} for "
-                    "{}".format(zmin, zmax, os.path.basename(filename)))
+                # print("DEBUG: Using default redshift range {:.4f}-{:.4f} for "
+                #     "{}".format(zmin, zmax, os.path.basename(filename)))
             else:
                 zmin = self._redshifts[0]
                 zmax = self._redshifts[-1]
-                print("DEBUG: Using redshift range {:.4f}-{:.4f} for "
-                    "{}".format(zmin, zmax, os.path.basename(filename)))
+                # print("DEBUG: Using redshift range {:.4f}-{:.4f} for "
+                #     "{}".format(zmin, zmax, os.path.basename(filename)))
 
             self._subtype = None
             if 'RRSUBTYP' in hdr:
@@ -158,9 +158,18 @@ class Template(object):
             raise ValueError(f'Template method {self._method} unrecognized; '
                               f'should be one of {valid_template_methods}')
 
-        print(f'INFO: {self.full_type} templates using {self._method} for fitting')
-        print(f'INFO: {self.full_type} templates using {self._igm_model} IGM model')
+        if filename is not None:
+            print(f'INFO: {os.path.basename(filename)} {self}')
+        else:
+            print(f'INFO: {self}')
 
+    def __str__(self):
+        zmin = round(self._redshifts[0], 4)
+        zmax = round(self._redshifts[-1], 4)
+        return f'{self._rrtype} {self._subtype} {self._method} IGM={self._igm_model} z={zmin}-{zmax}'
+
+    def __repr__(self):
+        return str(self)
 
     @property
     def nbasis(self):
@@ -254,8 +263,9 @@ def find_templates(template_path=None):
         print(f'DEBUG: Reading templates from {template_path}')
 
     if os.path.isdir(template_path):
-        default_templates_file = f'{template_path}/default_templates.txt'
+        default_templates_file = f'{template_path}/templates-default.txt'
         template_dir = template_path
+
     elif template_path.endswith('.txt'):
         if not os.path.exists(template_path):
             raise ValueError(f'Missing {template_path=}')
@@ -292,6 +302,65 @@ def find_templates(template_path=None):
 
     return template_files
 
+
+def header2templatefiles(hdr, template_dir=None):
+    """Derive template filenames from header keywords
+
+    Args:
+        hdr: dict-like with keys TEMNAMnn+TEMVERnn and/or TEMFILnn
+
+    Options:
+        template_dir (str): full path to redrock-templates directory
+
+    Returns list of template filenames, including directory path
+    """
+    filenames = list()
+    for i in range(100):
+        filekey = f'TEMFIL{i:02d}'
+        typekey = f'TEMNAM{i:02d}'
+        verkey = f'TEMVER{i:02d}'
+        if filekey in hdr:
+            filenames.append( hdr[filekey] )
+        elif (typekey in hdr) and (verkey in hdr):
+            version = hdr[verkey].strip()
+            blat = hdr[typekey].split(':::')  # SPECTYPE:::SUBTYPE or just SPECTYPE
+            spectype = blat[0].strip()
+            if len(blat) > 1:
+                subtype = blat[1].strip()
+            else:
+                subtype = None
+
+            #- special case unversioned STAR templates
+            if version=='unknown':
+                if spectype == 'STAR':
+                    version = '0.1'
+                else:
+                    raise ValueError(f'unknown version for {spectype=}')
+
+            filenames.append(f'rrtemplate-{spectype}-{subtype}-v{version}.fits')
+
+    #- preprend template directory
+    if template_dir is None:
+        template_dir = os.environ['RR_TEMPLATE_DIR']
+
+    filenames = [os.path.join(template_dir, fn) for fn in filenames]
+
+    return filenames
+
+
+def load_templates_from_header(hdr, template_dir=None):
+    """Return templates matching header keywords
+
+    Args:
+        hdr: dict-like with keys TEMNAMnn+TEMVERnn and/or TEMFILnn
+
+    Options:
+        template_dir (str): full path to redrock-templates directory
+
+    Returns list of Template objects
+    """
+    template_filenames = header2templatefiles(hdr, template_dir=template_dir)
+    return load_templates(template_filenames)
 
 def load_templates(template_path=None):
     """

--- a/py/redrock/test/test_io.py
+++ b/py/redrock/test/test_io.py
@@ -8,11 +8,10 @@ import numpy as np
 
 from .. import utils as rrutils
 from ..results import read_zscan, write_zscan
-from ..templates import DistTemplate, find_templates, load_templates, load_dist_templates
 from ..zfind import zfind
+from ..templates import DistTemplate
 
 from . import util
-
 
 class TestIO(unittest.TestCase):
 
@@ -22,41 +21,11 @@ class TestIO(unittest.TestCase):
         cls.testDir = tempfile.mkdtemp()        
         cls.testfile = os.path.join(cls.testDir, 'test-{uuid}.h5'.format(uuid=uuid1()))
 
-        # create dummy template files in a separate dir
-        cls.testTemplateDir = tempfile.mkdtemp()
-        cls.default_templates = (
-                'rrtemplate-galaxy-v2.fits',
-                'rrtemplate-qso-v1.fits',
-                )
-        cls.alternate_templates = (
-                'rrtemplate-galaxy-v1.fits',
-                'rrtemplate-blat-v1.fits',
-                )
-
-        for filename in cls.default_templates + cls.alternate_templates:
-            with open(f'{cls.testTemplateDir}/{filename}', 'w'):
-                pass
-
-        with open(cls.testTemplateDir + '/default_templates.txt', 'w') as fx:
-            fx.write('# Header comment\n')
-            fx.write('\n')
-            for filename in cls.default_templates:
-                fx.write(f'{filename}\n')
-
-        with open(cls.testTemplateDir + '/alternate_templates.txt', 'w') as fx:
-            fx.write('# Header comment\n')
-            fx.write('\n')
-            for filename in cls.alternate_templates:
-                fx.write(f'{filename}\n')
-
     #- Cleanup test files if they exist
     @classmethod
     def tearDownClass(cls):
         if os.path.exists(cls.testfile):
             os.remove(cls.testfile)
-
-        if os.path.isdir(cls.testDir):
-            rmtree(cls.testDir)
 
     def setUp(self):
         #- remove testfile if leftover from a previous test
@@ -72,60 +41,6 @@ class TestIO(unittest.TestCase):
             self.assertTrue(x1 is rrutils.native_endian(x1))
         else:
             self.assertTrue(x2 is rrutils.native_endian(x2))
-
-    ### @unittest.skipIf('RR_TEMPLATE_DIR' not in os.environ, '$RR_TEMPLATE_DIR not set')
-    def test_find_templates(self):
-        templates = find_templates()
-        self.assertTrue(len(templates) > 0)
-        template_dir = os.path.dirname(templates[0])
-        templates = find_templates(template_dir)
-        self.assertTrue(len(templates) > 0)
-
-        template_dir = os.path.dirname(templates[0])
-        templates = find_templates(template_dir)
-        self.assertTrue(len(templates) > 0)
-
-        templates = find_templates(self.testTemplateDir)
-        self.assertEqual(len(templates), len(self.default_templates))
-        for filename in templates:
-            self.assertIn(os.path.basename(filename), self.default_templates)
-
-        templates = find_templates(self.testTemplateDir+'/alternate_templates.txt')
-        self.assertEqual(len(templates), len(self.alternate_templates))
-        for filename in templates:
-            self.assertIn(os.path.basename(filename), self.alternate_templates)
-
-        with self.assertRaises(ValueError):
-            templates = find_templates(self.testTemplateDir+'/blat.txt')
-
-        with self.assertRaises(ValueError):
-            templates = find_templates('blat.txt')
-
-        with self.assertRaises(ValueError):
-            templates = find_templates('blat.foo')
-
-
-    def test_load_templates(self):
-        templates = load_templates()
-        self.assertTrue(len(templates) > 0)
-
-        template_files = find_templates()
-        templates = load_templates(template_files[0:2])
-        self.assertEqual(len(templates), 2)
-
-
-    ### @unittest.skipIf('RR_TEMPLATE_DIR' not in os.environ, '$RR_TEMPLATE_DIR not set')
-    def test_load_dist_templates(self):
-        dtarg = util.fake_targets()
-        dwave = dtarg.wavegrids()
-        for dtp in load_dist_templates(dwave):
-            self.assertIn('wave', dtp.template.__dict__)
-            self.assertIn('flux', dtp.template.__dict__)
-            wave = dtp.template.wave
-            flux = dtp.template.flux
-            self.assertEqual(wave.shape[0], flux.shape[1])
-            self.assertEqual(wave.ndim, 1)
-            self.assertEqual(flux.ndim, 2)
 
     def test_zscan_io(self):
         dtarg = util.fake_targets()

--- a/py/redrock/test/test_templates.py
+++ b/py/redrock/test/test_templates.py
@@ -18,6 +18,7 @@ class TestTemplates(unittest.TestCase):
     def setUpClass(cls):
         cls.testDir = tempfile.mkdtemp()        
         cls.testfile = os.path.join(cls.testDir, 'test-{uuid}.h5'.format(uuid=uuid1()))
+        cls.starting_cwd = os.getcwd()
 
         # create dummy template files in a separate dir
         cls.testTemplateDir = tempfile.mkdtemp()
@@ -60,6 +61,9 @@ class TestTemplates(unittest.TestCase):
         if os.path.exists(self.testfile):
             os.remove(self.testfile)
 
+        #- make sure we are in starting directory every time
+        os.chdir(self.starting_cwd)
+
     ### @unittest.skipIf('RR_TEMPLATE_DIR' not in os.environ, '$RR_TEMPLATE_DIR not set')
     def test_find_templates(self):
         templates = find_templates()
@@ -78,6 +82,12 @@ class TestTemplates(unittest.TestCase):
             self.assertIn(os.path.basename(filename), self.default_templates)
 
         templates = find_templates(self.testTemplateDir+'/templates-alternate.txt')
+
+        # works without a path prefix
+        os.chdir(self.testTemplateDir)
+        templates = find_templates('templates-alternate.txt')
+        os.chdir(self.starting_cwd)
+
         self.assertEqual(len(templates), len(self.alternate_templates))
         for filename in templates:
             self.assertIn(os.path.basename(filename), self.alternate_templates)

--- a/py/redrock/test/test_templates.py
+++ b/py/redrock/test/test_templates.py
@@ -1,0 +1,166 @@
+from __future__ import division, print_function
+
+import os, tempfile
+from shutil import rmtree
+import unittest
+from uuid import uuid1
+import numpy as np
+
+from .. import utils as rrutils
+from ..templates import DistTemplate, find_templates, load_templates, load_dist_templates
+
+from . import util as testutil
+
+class TestTemplates(unittest.TestCase):
+
+    #- Create unique test filename in a subdirectory
+    @classmethod
+    def setUpClass(cls):
+        cls.testDir = tempfile.mkdtemp()        
+        cls.testfile = os.path.join(cls.testDir, 'test-{uuid}.h5'.format(uuid=uuid1()))
+
+        # create dummy template files in a separate dir
+        cls.testTemplateDir = tempfile.mkdtemp()
+        cls.default_templates = (
+                'rrtemplate-galaxy-v2.fits',
+                'rrtemplate-qso-v1.fits',
+                )
+        cls.alternate_templates = (
+                'rrtemplate-galaxy-v1.fits',
+                'rrtemplate-blat-v1.fits',
+                )
+
+        for filename in cls.default_templates + cls.alternate_templates:
+            with open(f'{cls.testTemplateDir}/{filename}', 'w'):
+                pass
+
+        with open(cls.testTemplateDir + '/templates-default.txt', 'w') as fx:
+            fx.write('# Header comment\n')
+            fx.write('\n')
+            for filename in cls.default_templates:
+                fx.write(f'{filename}\n')
+
+        with open(cls.testTemplateDir + '/templates-alternate.txt', 'w') as fx:
+            fx.write('# Header comment\n')
+            fx.write('\n')
+            for filename in cls.alternate_templates:
+                fx.write(f'{filename}\n')
+
+    #- Cleanup test files if they exist
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(cls.testfile):
+            os.remove(cls.testfile)
+
+        if os.path.isdir(cls.testDir):
+            rmtree(cls.testDir)
+
+    def setUp(self):
+        #- remove testfile if leftover from a previous test
+        if os.path.exists(self.testfile):
+            os.remove(self.testfile)
+
+    ### @unittest.skipIf('RR_TEMPLATE_DIR' not in os.environ, '$RR_TEMPLATE_DIR not set')
+    def test_find_templates(self):
+        templates = find_templates()
+        self.assertTrue(len(templates) > 0)
+        template_dir = os.path.dirname(templates[0])
+        templates = find_templates(template_dir)
+        self.assertTrue(len(templates) > 0)
+
+        template_dir = os.path.dirname(templates[0])
+        templates = find_templates(template_dir)
+        self.assertTrue(len(templates) > 0)
+
+        templates = find_templates(self.testTemplateDir)
+        self.assertEqual(len(templates), len(self.default_templates))
+        for filename in templates:
+            self.assertIn(os.path.basename(filename), self.default_templates)
+
+        templates = find_templates(self.testTemplateDir+'/templates-alternate.txt')
+        self.assertEqual(len(templates), len(self.alternate_templates))
+        for filename in templates:
+            self.assertIn(os.path.basename(filename), self.alternate_templates)
+
+        with self.assertRaises(ValueError):
+            templates = find_templates(self.testTemplateDir+'/blat.txt')
+
+        with self.assertRaises(ValueError):
+            templates = find_templates('blat.txt')
+
+        with self.assertRaises(ValueError):
+            templates = find_templates('blat.foo')
+
+    def test_load_templates(self):
+        templates = load_templates()
+        self.assertTrue(len(templates) > 0)
+
+        template_files = find_templates()
+        templates = load_templates(template_files[0:2])
+        self.assertEqual(len(templates), 2)
+
+    ### @unittest.skipIf('RR_TEMPLATE_DIR' not in os.environ, '$RR_TEMPLATE_DIR not set')
+    def test_load_dist_templates(self):
+        dtarg = testutil.fake_targets()
+        dwave = dtarg.wavegrids()
+        for dtp in load_dist_templates(dwave):
+            self.assertIn('wave', dtp.template.__dict__)
+            self.assertIn('flux', dtp.template.__dict__)
+            wave = dtp.template.wave
+            flux = dtp.template.flux
+            self.assertEqual(wave.shape[0], flux.shape[1])
+            self.assertEqual(wave.ndim, 1)
+            self.assertEqual(flux.ndim, 2)
+
+    def test_header2templatefiles(self):
+        """Test templates.header2templatefiles"""
+        from ..templates import header2templatefiles
+
+        #- Derive filenames from TEMNAM/TEMVER, with whitespace
+        #- STAR version unknown defaults to 0.1
+        hdr = dict(
+                TEMNAM00='GALAXY  ',  TEMVER00='2.6     ',
+                TEMNAM01='QSO:::HIZ', TEMVER01='1.0     ',
+                TEMNAM02='STAR:::M',  TEMVER02='unknown ',
+            )
+        filenames = header2templatefiles(hdr)
+        self.assertTrue(filenames[0].endswith('rrtemplate-GALAXY-None-v2.6.fits'), f'Wrong {filenames[0]}')
+        self.assertTrue(filenames[1].endswith('rrtemplate-QSO-HIZ-v1.0.fits'),     f'Wrong {filenames[1]}')
+        self.assertTrue(filenames[2].endswith('rrtemplate-STAR-M-v0.1.fits'),      f'Wrong {filenames[2]}')
+
+        #- Derive filenames from TEMNAM/TEMVER, no whitespace
+        #- star version used if not "unknown"
+        hdr = dict(
+                TEMNAM00='GALAXY',    TEMVER00='2.6',
+                TEMNAM01='QSO:::HIZ', TEMVER01='1.0',
+                TEMNAM02='STAR:::M',  TEMVER02='3.14',
+            )
+        filenames = header2templatefiles(hdr)
+        self.assertTrue(filenames[0].endswith('rrtemplate-GALAXY-None-v2.6.fits'), f'Wrong {filenames[0]}')
+        self.assertTrue(filenames[1].endswith('rrtemplate-QSO-HIZ-v1.0.fits'),     f'Wrong {filenames[1]}')
+        self.assertTrue(filenames[2].endswith('rrtemplate-STAR-M-v3.14.fits'),     f'Wrong {filenames[2]}')
+
+        #- TEMFIL overrides TEMNAM/TEMVER if it exists
+        hdr = dict(
+                TEMNAM00='GALAXY',    TEMVER00='2.6',  TEMFIL00='blat.fits',
+                TEMNAM01='QSO:::HIZ', TEMVER01='1.0',  TEMFIL01='foo.fits',
+                TEMNAM02='STAR:::M',  TEMVER02='3.14', TEMFIL02='bar.fits'
+            )
+        filenames = header2templatefiles(hdr)
+        self.assertTrue(filenames[0].endswith('blat.fits'), f'Wrong {filenames[0]}')
+        self.assertTrue(filenames[1].endswith('foo.fits'),  f'Wrong {filenames[1]}')
+        self.assertTrue(filenames[2].endswith('bar.fits'),  f'Wrong {filenames[2]}')
+
+        #- Testing future possibilities for GALAXY suptypes
+        #- Also test dict entries "out of order"
+        hdr = dict(
+                TEMNAM00='GALAXY:::BGS',    TEMVER00='3.0',
+                TEMNAM02='GALAXY:::LRG',    TEMVER02='3.0',
+                TEMNAM01='GALAXY:::ELG',    TEMVER01='3.0',
+            )
+        filenames = header2templatefiles(hdr)
+        self.assertTrue(filenames[0].endswith('rrtemplate-GALAXY-BGS-v3.0.fits'), f'Wrong {filenames[0]}')
+        self.assertTrue(filenames[1].endswith('rrtemplate-GALAXY-ELG-v3.0.fits'), f'Wrong {filenames[1]}')
+        self.assertTrue(filenames[2].endswith('rrtemplate-GALAXY-LRG-v3.0.fits'), f'Wrong {filenames[2]}')
+
+

--- a/py/redrock/test/test_templates.py
+++ b/py/redrock/test/test_templates.py
@@ -123,7 +123,7 @@ class TestTemplates(unittest.TestCase):
                 TEMNAM01='QSO:::HIZ', TEMVER01='1.0     ',
                 TEMNAM02='STAR:::M',  TEMVER02='unknown ',
             )
-        filenames = header2templatefiles(hdr)
+        filenames = header2templatefiles(hdr, template_dir=self.testTemplateDir)
         self.assertTrue(filenames[0].endswith('rrtemplate-GALAXY-None-v2.6.fits'), f'Wrong {filenames[0]}')
         self.assertTrue(filenames[1].endswith('rrtemplate-QSO-HIZ-v1.0.fits'),     f'Wrong {filenames[1]}')
         self.assertTrue(filenames[2].endswith('rrtemplate-STAR-M-v0.1.fits'),      f'Wrong {filenames[2]}')
@@ -135,7 +135,7 @@ class TestTemplates(unittest.TestCase):
                 TEMNAM01='QSO:::HIZ', TEMVER01='1.0',
                 TEMNAM02='STAR:::M',  TEMVER02='3.14',
             )
-        filenames = header2templatefiles(hdr)
+        filenames = header2templatefiles(hdr, template_dir=self.testTemplateDir)
         self.assertTrue(filenames[0].endswith('rrtemplate-GALAXY-None-v2.6.fits'), f'Wrong {filenames[0]}')
         self.assertTrue(filenames[1].endswith('rrtemplate-QSO-HIZ-v1.0.fits'),     f'Wrong {filenames[1]}')
         self.assertTrue(filenames[2].endswith('rrtemplate-STAR-M-v3.14.fits'),     f'Wrong {filenames[2]}')
@@ -146,7 +146,7 @@ class TestTemplates(unittest.TestCase):
                 TEMNAM01='QSO:::HIZ', TEMVER01='1.0',  TEMFIL01='foo.fits',
                 TEMNAM02='STAR:::M',  TEMVER02='3.14', TEMFIL02='bar.fits'
             )
-        filenames = header2templatefiles(hdr)
+        filenames = header2templatefiles(hdr, template_dir=self.testTemplateDir)
         self.assertTrue(filenames[0].endswith('blat.fits'), f'Wrong {filenames[0]}')
         self.assertTrue(filenames[1].endswith('foo.fits'),  f'Wrong {filenames[1]}')
         self.assertTrue(filenames[2].endswith('bar.fits'),  f'Wrong {filenames[2]}')
@@ -158,7 +158,7 @@ class TestTemplates(unittest.TestCase):
                 TEMNAM02='GALAXY:::LRG',    TEMVER02='3.0',
                 TEMNAM01='GALAXY:::ELG',    TEMVER01='3.0',
             )
-        filenames = header2templatefiles(hdr)
+        filenames = header2templatefiles(hdr, template_dir=self.testTemplateDir)
         self.assertTrue(filenames[0].endswith('rrtemplate-GALAXY-BGS-v3.0.fits'), f'Wrong {filenames[0]}')
         self.assertTrue(filenames[1].endswith('rrtemplate-GALAXY-ELG-v3.0.fits'), f'Wrong {filenames[1]}')
         self.assertTrue(filenames[2].endswith('rrtemplate-GALAXY-LRG-v3.0.fits'), f'Wrong {filenames[2]}')


### PR DESCRIPTION
This PR adds `redrock.templates.load_templates_from_header` to support loading the correct template versions to match a particular Redrock run, based upon the TEMNAMnn/TEMVERnn keywords which we have already been outputing.

This function requires the restructured redrock-templates directory+filenames in /global/cfs/cdirs/desi/users/sjbailey/code/redrock-templates/ .  Once this PR is reviewed and merged, we can commit that updated structure.

It also adds support for a future keyword TEMFILnn keyword to explicitly give the filename instead of deriving it from TEMNAMnn=SPECTYPE:::SUBTYPE and TEMVERnn=VERSION -> rrtemplate-SPECTYPE-SUBTYPE-vVERSION.fits.  I'll add this in a separate PR only after we've switched to the new redrock-templates structure so that we don't accidentally write files with TEMFILnn listing an old incompatible template filename.

Example usage
```python
import os
import fitsio
from redrock.templates import load_templates_from_header

os.environ['RR_TEMPLATE_DIR']='/global/cfs/cdirs/desi/users/sjbailey/code/redrock-templates/'
hdr_fuji = fitsio.read_header('/global/cfs/cdirs/desi/spectro/redux/fuji/zcatalog/zpix-sv3-dark.fits', 1)
hdr_iron = fitsio.read_header('/global/cfs/cdirs/desi/spectro/redux/iron/zcatalog/v1/zpix-sv3-dark.fits', 1)
templates_fuji = load_templates_from_header(hdr_fuji)
templates_iron = load_templates_from_header(hdr_iron)
```

Output when loading Fuji templates:
```
INFO: rrtemplate-GALAXY-None-v2.6.fits GALAXY  PCA IGM=Calura12 z=-0.005-1.6997
INFO: rrtemplate-QSO-None-v0.1.fits QSO  PCA IGM=Calura12 z=0.05-5.9934
...
```

Output when loading Iron templates:
```
INFO: rrtemplate-GALAXY-None-v2.6.fits GALAXY  PCA IGM=Calura12 z=-0.005-1.6997
INFO: rrtemplate-QSO-HIZ-v1.0.fits QSO HIZ PCA IGM=Calura12 z=1.4-6.993
INFO: rrtemplate-QSO-LOZ-v1.0.fits QSO LOZ PCA IGM=Calura12 z=0.05-1.5983
...
```

Note that it correctly loaded the same GALAXY template but different QSO templates for Fuji vs. Iron, all from a single RR_TEMPLATE_DIR.