### PR TITLE
Add units to Redrock fibermap output 

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ redrock Change Log
 0.19.0 (unreleased)
 -------------------
 
+* Add units to fibermap output (PR `#292`_).
 * Write test files to temporary directory (PR `#263`_).
 * Check template dimension so code works on a single template (PR `#264`_). 
 * Versioned templates, NMF support, and updated IGM models (PR `#271`_).
@@ -18,7 +19,6 @@ redrock Change Log
   * Fix --archetype_nnearest option (PR `#272`_).
   * fix --archetype-legendre-degree=0 crash corner case (PR `#278`_).
 
-
 .. _`#263`: https://github.com/desihub/redrock/pull/263
 .. _`#264`: https://github.com/desihub/redrock/pull/264
 .. _`#265`: https://github.com/desihub/redrock/pull/265
@@ -29,6 +29,7 @@ redrock Change Log
 .. _`#278`: https://github.com/desihub/redrock/pull/278
 .. _`#282`: https://github.com/desihub/redrock/pull/282
 .. _`#289`: https://github.com/desihub/redrock/pull/289
+.. _`#292`: https://github.com/desihub/redrock/pull/292
 
 0.18.0 (2023-09-14)
 -------------------

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -24,6 +24,7 @@ from desispec.resolution import Resolution
 from desispec.coaddition import coadd_fibermap
 from desispec.specscore import compute_coadd_tsnr_scores
 from desispec.maskbits import fibermask
+from desispec.io.fibermap import annotate_fibermap
 
 from ..utils import elapsed, get_mp, distribute_work, getGPUCountMPI
 
@@ -93,7 +94,8 @@ def write_zbest(outfile, zbest, fibermap, exp_fibermap, tsnr2,
     hx = fits.HDUList()
     hx.append(fits.PrimaryHDU(header=header))
     hx.append(fits.convenience.table_to_hdu(zbest))
-    hx.append(fits.convenience.table_to_hdu(fibermap))
+    # ADM annotate_fibermap adds units to fibermap HDUs.
+    hx.append(annotate_fibermap(fits.convenience.table_to_hdu(fibermap)))
     hx.append(fits.convenience.table_to_hdu(exp_fibermap))
     hx.append(fits.convenience.table_to_hdu(tsnr2))
 


### PR DESCRIPTION
This PR uses `desispec.io.fibermap.annotate_fibermap()` to add units to `Redrock` fibermap output. It should fix #284.

Example output files before and after adding units are at:

`/pscratch/sd/a/adamyers/foo.fits` (before)
`/pscratch/sd/a/adamyers/blat.fits` (after)

These are created via, e.g. `rrdesi -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/3351/20230905/coadd-0-3351-thru20230905.fits --outfile $SCRATCH/blat.fits --ntargets 5`.

An example test that the units were added:

```
import fitsio
import numpy as np
newhdr = fitsio.read_header("/pscratch/sd/a/adamyers/blat.fits", "FIBERMAP")
oldhdr = fitsio.read_header("/pscratch/sd/a/adamyers/foo.fits", "FIBERMAP")
print(np.any(["UNIT" in col for col in oldhdr]))
print(np.any(["UNIT" in col for col in newhdr]))
False
True
```

Units are skipped for 5 columns that are not covered by `desispec.io.fibermap.annotate_fibermap()`:

```
MEAN_MJD
MIN_MJD
MAX_MJD
FIRSTNIGHT
LASTNIGHT
```
I'll open an issue and start a PR to add those columns over in `desispec`.