### PR TITLE
Default to a special template for ZWARN of NODATA cases

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,11 @@ redrock Change Log
 0.19.1 (unreleased)
 -------------------
 
+* Set ZWARN/NODATA to z=0 GALAXY, no SUBTYPE, zero coefficients (PR `#294`_).
 * Add units to fibermap output (PR `#292`_).
 
 .. _`#292`: https://github.com/desihub/redrock/pull/292
+.. _`#294`: https://github.com/desihub/redrock/pull/294
 
 0.19.0 (2024-04-19)
 -------------------

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -943,6 +943,10 @@ def rrdesi(options=None, comm=None):
 
             ii = np.isin(zfit['targetid'], targetids[badpos | broken | unassigned | bad])
             zfit['zwarn'][ii] |= ZWarningMask.NODATA
+            # ADM set NODATA cases to z=0, GALAXY with zero coefficients.
+            zfit['spectype'][ii] = 'GALAXY'
+            zfit['subtype'][ii] = ''
+            zfit['coeff'][ii] = 0.
 
             ii = np.isin(zfit['targetid'], targetids[broken])
             zfit['zwarn'][ii] |= ZWarningMask.UNPLUGGED


### PR DESCRIPTION
This PR sets `ZWARN` of `NODATA` cases to a z=0, `GALAXY` with blank `SUBTYPE` and zero coefficients.

It should address #224.

Example output files processed via:

```rrdesi -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/3351/20230905/coadd-1-3351-thru20230905.fits --outfile $SCRATCH/new.fits --ntargets 15```

are at:

`/pscratch/sd/a/adamyers/old.fits` (before this PR)
`/pscratch/sd/a/adamyers/new.fits` (after this PR)

Test of the desired outcome:

```
import fitsio
a = fitsio.read("/pscratch/sd/a/adamyers/old.fits")
b = fitsio.read("/pscratch/sd/a/adamyers/new.fits")
print(a[[5, 14]][["ZWARN", "COEFF", "SPECTYPE", "SUBTYPE"]])
print(b[[5, 14]][["ZWARN", "COEFF", "SPECTYPE", "SUBTYPE"]])

[(516, [ 6.13320718e+01, -7.90512496e+01,  4.09394471e+01, -4.52058606e+01,  2.58237348e+00,  2.92976339e+00,  1.51155349e+01,  1.33815240e-01, -4.78952134e+00,  8.33736341e+00], 'GALAXY', '')
 (516, [-2.85894625e-02,  8.61347220e+02,  1.78825596e+00, -2.12392741e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00], 'QSO', 'LOZ')]
[(516, [0., 0., 0., 0., 0., 0., 0., 0., 0., 0.], 'GALAXY', '')
 (516, [0., 0., 0., 0., 0., 0., 0., 0., 0., 0.], 'GALAXY', '')]
```