### PR TITLE
add TEMFILnn keywords with full template filenames

### DIFF
--- a/py/redrock/archetypes.py
+++ b/py/redrock/archetypes.py
@@ -31,6 +31,7 @@ class Archetype():
     def __init__(self, filename):
 
         # Load the file
+        self._filename = filename
         h = fits.open(os.path.expandvars(filename), memmap=False)
 
         hdr = h['ARCHETYPES'].header
@@ -81,6 +82,27 @@ class Archetype():
             import cupy as cp
             self._gpuflux = cp.asarray(self.flux)
         return self._gpuflux
+
+    @property
+    def version(self):
+        return self._version
+
+    @property
+    def filename(self):
+        return self._filename
+
+    #- template_type, sub_type, and full_type like Template object methods
+    @property
+    def template_type(self):
+        return self._rrtype
+
+    @property
+    def sub_type(self):
+        return self._subtype
+
+    @property
+    def full_type(self):
+        return self._full_type
 
     def rebin_template(self,index,z,dwave,trapz=True):
         """

--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -35,8 +35,10 @@ class Template(object):
     def __init__(self, filename=None, spectype=None, redshifts=None,
                  wave=None, flux=None, subtype=None, method='PCA',
                  igm_model='Inoue14',
-                 zscan_galaxy=None, zscan_qso=None, zscan_star=None):
+                 zscan_galaxy=None, zscan_qso=None, zscan_star=None,
+                 version=None):
 
+        self._filename = filename
         if filename is not None:
             fx = None
             if os.path.exists(filename):
@@ -143,6 +145,7 @@ class Template(object):
             self._subtype = subtype
             self._igm_model = igm_model
             self._method = method
+            self._version = version
 
         self._nbasis = self.flux.shape[0]
         self._nwave = self.flux.shape[1]
@@ -195,6 +198,14 @@ class Template(object):
             return '{}:::{}'.format(self._rrtype, self._subtype)
         else:
             return self._rrtype
+
+    @property
+    def version(self):
+        return self._version
+
+    @property
+    def filename(self):
+        return self._filename
 
     @property
     def redshifts(self):

--- a/py/redrock/test/test_templates.py
+++ b/py/redrock/test/test_templates.py
@@ -109,6 +109,10 @@ class TestTemplates(unittest.TestCase):
         templates = load_templates(template_files[0:2])
         self.assertEqual(len(templates), 2)
 
+        self.assertEqual(templates[0].filename, template_files[0])
+        self.assertEqual(templates[1].filename, template_files[1])
+
+
     ### @unittest.skipIf('RR_TEMPLATE_DIR' not in os.environ, '$RR_TEMPLATE_DIR not set')
     def test_load_dist_templates(self):
         dtarg = testutil.fake_targets()


### PR DESCRIPTION
@moustakas this is the followup PR to #290 to save the template filenames in the output headers as TEMFILnn keywods to support non-standard template names.  This is supported by `redrock.templates.load_templates_from_header` to read them back in.

Example:
```
echo $RR_TEMPLATE_DIR
cat $RR_TEMPLATE_DIR/templates-test.txt
rrdesi -n 16 \
  -i $CFS/desi/spectro/redux/iron/tiles/cumulative/80605/20210205/coadd-6-80605-thru20210205.fits \
  -t $RR_TEMPLATE_DIR/templates-test.txt \
  -o $SCRATCH/redrock/redrock-test-keywords.fits
fitsheader -e 0 $SCRATCH/redrock/redrock-test-keywords.fits
```

Results:
```
/global/common/software/desi/users/sjbailey/redrock-templates
rrtemplate-GALAXY-None-v2.6.fits
rrtemplate-QSO-SuperDuperWow.fits
...
TEMNAM00= 'GALAXY  '                                                            
TEMVER00= '2.6     '                                                            
TEMFIL00= 'rrtemplate-GALAXY-None-v2.6.fits'                                    
TEMNAM01= 'QSO:::LOZ'                                                           
TEMVER01= '1.0     '                                                            
TEMFIL01= 'rrtemplate-QSO-SuperDuperWow.fits'                                   
...
DEPNAM19= 'RR_TEMPLATE_DIR'                                                     
DEPVER19= '/global/common/software/desi/users/sjbailey/redrock-templates'       
```

Loading those templates using the header:
```python
import fitsio
from redrock.templates import load_templates_from_header
hdr = fitsio.read_header('/pscratch/sd/s/sjbailey/redrock/redrock-test-keywords.fits')
templates = load_templates_from_header(hdr)
```
Results:
```
Reading templates from ['/global/common/software/desi/users/sjbailey/redrock-templates/rrtemplate-GALAXY-None-v2.6.fits', '/global/common/software/desi/users/sjbailey/redrock-templates/rrtemplate-QSO-SuperDuperWow.fits']
INFO: rrtemplate-GALAXY-None-v2.6.fits GALAXY  PCA IGM=Calura12 z=-0.005-1.6997
INFO: rrtemplate-QSO-SuperDuperWow.fits QSO LOZ PCA IGM=Calura12 z=0.05-1.5983
```

Note: this does *not* implement the other idea in PR #290 to support past runs without TEMFILnn keywords, where it reads every template it can find and tries to match it up to the TEMNAMnn and TEMVERnn keywords.  Let's save that for a different PR if we really really need it.
