### PR TITLE
include negative [OII] flux penalty in final minimization

### DIFF
--- a/py/redrock/fitz.py
+++ b/py/redrock/fitz.py
@@ -16,6 +16,7 @@ from . import constants
 from .rebin import rebin_template
 
 from .zscan import calc_zchi2_one, spectral_data, calc_zchi2_batch
+from .zscan import calc_negOII_penalty
 
 from .zwarning import ZWarningMask as ZW
 
@@ -259,11 +260,8 @@ def fitz(zchi2, redshifts, target, template, nminima=3, archetype=None, use_gpu=
                                                  use_gpu=use_gpu)
 
         #- Penalize chi2 for negative [OII] flux; ad-hoc
-        zzchi2penalty = zzchi2 * 0.
-        if template.template_type == 'GALAXY':
-            OIIflux = np.sum(zzcoeff @ OIItemplate.T, axis=1)
-            zzchi2penalty[OIIflux < 0] = -OIIflux[OIIflux < 0]
-        zzchi2 += zzchi2penalty
+        if hasattr(template, 'OIItemplate'):
+            zzchi2 += calc_negOII_penalty(template.OIItemplate, zzcoeff)
 
         #- fit parabola to 3 points around minimum
         i = min(max(np.argmin(zzchi2),1), len(zz)-2)

--- a/py/redrock/fitz.py
+++ b/py/redrock/fitz.py
@@ -177,11 +177,6 @@ def fitz(zchi2, redshifts, target, template, nminima=3, archetype=None, use_gpu=
 
     (weights, flux, wflux) = spectral_data(spectra)
 
-    # Redshifts near [OII]; used only for galaxy templates
-    if template.template_type == 'GALAXY':
-        isOII = (3724 <= template.wave) & (template.wave <= 3733)
-        OIItemplate = template.flux[:, isOII].T
-     
     if (use_gpu):
         #Get CuPy arrays of weights, flux, wflux
         #These are created on the first call of gpu_spectral_data() for a

--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -158,10 +158,10 @@ class Template(object):
             raise ValueError(f'Template method {self._method} unrecognized; '
                               f'should be one of {valid_template_methods}')
 
-        #- Special case for GALAXY templates: cache subset of template that
-        #- covers [OII] but only for GALAXY templates and fitting methods which
-        #- can include negative templates or coefficients.
-        if self._rrtype == 'GALAXY' and not self._method in ("NMF", "NNLS"):
+        # Special case for GALAXY templates and PCA fitting, which can include
+        # negative templates or coefficients: Cache a template that covers just
+        # [OII].
+        if self._rrtype == 'GALAXY' and self._method == "PCA":
             isOII = (3724 <= self.wave) & (self.wave <= 3733)
             self.OIItemplate = self.flux[:,isOII]
 

--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -158,6 +158,12 @@ class Template(object):
             raise ValueError(f'Template method {self._method} unrecognized; '
                               f'should be one of {valid_template_methods}')
 
+        #- Special case for GALAXY templates: cache subset of template
+        #- that covers [OII]
+        if self._rrtype == 'GALAXY':
+            isOII = (3724 <= self.wave) & (self.wave <= 3733)
+            self.OIItemplate = self.flux[:,isOII]
+
         if filename is not None:
             print(f'INFO: {os.path.basename(filename)} {self}')
         else:

--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -158,9 +158,10 @@ class Template(object):
             raise ValueError(f'Template method {self._method} unrecognized; '
                               f'should be one of {valid_template_methods}')
 
-        #- Special case for GALAXY templates: cache subset of template
-        #- that covers [OII]
-        if self._rrtype == 'GALAXY':
+        #- Special case for GALAXY templates: cache subset of template that
+        #- covers [OII] but only for GALAXY templates and fitting methods which
+        #- can include negative templates or coefficients.
+        if self._rrtype == 'GALAXY' and not self._method in ("NMF", "NNLS"):
             isOII = (3724 <= self.wave) & (self.wave <= 3733)
             self.OIItemplate = self.flux[:,isOII]
 

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -609,7 +609,8 @@ def calc_batch_dot_product_3d3d_gpu(a, b, transpose_a=False, fullprecision=True)
 ###    are very obviously analagous though and should be highly
 ###    maintainable.  The main difference is the extra loop on the CPU version
 
-def calc_zchi2_batch(spectra, tdata, weights, flux, wflux, nz, nbasis, solve_matrices_algorithm=None, solver_args=None, use_gpu=False, fullprecision=True, prior=None):
+def calc_zchi2_batch(spectra, tdata, weights, flux, wflux, nz, nbasis, solve_matrices_algorithm=None,
+                     solver_args=None, use_gpu=False, fullprecision=True, prior=None):
     
     """Calculate a batch of chi2.
     For many redshifts and a set of spectral data, compute the chi2 for
@@ -863,12 +864,14 @@ def calc_zchi2(target_ids, target_data, dtemplate, progress=None, use_gpu=False)
         # for all templates for all three spectra for this target
 
         # For coarse z scan, use fullprecision = False to maximize speed
-        (zchi2[j,:], zcoeff[j,:,:]) = calc_zchi2_batch(target_data[j].spectra, tdata, weights, flux, wflux, nz, nbasis, dtemplate.template.solve_matrices_algorithm, use_gpu=use_gpu, fullprecision=False)
+        (zchi2[j,:], zcoeff[j,:,:]) = calc_zchi2_batch(
+            target_data[j].spectra, tdata, weights, flux, wflux, nz, nbasis,
+            dtemplate.template.solve_matrices_algorithm, use_gpu=use_gpu,
+            fullprecision=False)
 
         #- Galaxy templates penalize chi2 for negative [OII] flux; ad-hoc
         if hasattr(dtemplate.template, 'OIItemplate'):
-            zchi2penalty[j] = calc_negOII_penalty(
-                                   dtemplate.template.OIItemplate, zcoeff[j])
+            zchi2penalty[j] = calc_negOII_penalty(dtemplate.template.OIItemplate, zcoeff[j])
 
         if dtemplate.comm is None and progress is not None:
             progress.put(1)

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -781,11 +781,7 @@ def calc_negOII_penalty(OIItemplate, coeff):
 
     #- Linear penalty with negative [OII]; no mathematical basis but
     #- pragmatically works ok
-    try:
-        penalty = -OIIflux * (OIIflux < 0)
-    except Exception as err:
-        print(f'BLAT {OIItemplate.shape=} {coeff.shape=}')
-        raise err
+    penalty = -OIIflux * (OIIflux < 0)
 
     return penalty
 


### PR DESCRIPTION
This PR is a simple attempt to address #248. I haven't tested it extensively, but trying to get it up for review sooner rather than later.

Note that the ad hoc "penalize negative [OII] flux" should go away (or be turned off) once we move to NMF templates.