### PR TITLE
fix #250

### DIFF
--- a/py/redrock/utils.py
+++ b/py/redrock/utils.py
@@ -163,6 +163,9 @@ def mp_array(original):
     Returns;
         ndarray: the wrapped data.
 
+    If the input array has size=0, the original is returned without
+    wrapping it in a size=0 multiprocessing.RawArray (which generates
+    warnings)
     """
     import multiprocessing as mp
 

--- a/py/redrock/utils.py
+++ b/py/redrock/utils.py
@@ -166,6 +166,11 @@ def mp_array(original):
     """
     import multiprocessing as mp
 
+    # A zero-length array generates the warning documented in
+    # https://github.com/desihub/redrock/issues/250; capture it.
+    if original.size == 0:
+        return original
+    
     typecode = original.dtype.char
     shape = original.shape
 


### PR DESCRIPTION
This should fix #250. Basically, a zero-length array passed to `utils.mp_array` was generating a small, but annoying warning, so just capture that special case.
