### PR TITLE
fixing inconsistent legendre wavelength basis (#291)

### DIFF
--- a/py/redrock/archetypes.py
+++ b/py/redrock/archetypes.py
@@ -157,9 +157,6 @@ class Archetype():
         deg_legendre = (coeff!=0.).size-1
         index = np.arange(self._narch)[self._subtype==subtype][0]
 
-        #w = np.concatenate([ w for w in dwave.values() ])
-        #wave_min = w.min()
-        #wave_max = w.max()
         legendre = np.array([scipy.special.legendre(i)(reduced_wavelength(w)) for i in range(deg_legendre)])
         binned = trapz_rebin((1+z)*self.wave, self.flux[index], wave)*transmission_Lyman(z,wave,model=self.igm_model)
         flux = np.append(binned[None,:],legendre, axis=0)

--- a/py/redrock/archetypes.py
+++ b/py/redrock/archetypes.py
@@ -11,6 +11,8 @@ import numpy as np
 from scipy.interpolate import interp1d
 import scipy.special
 
+from .utils import reduced_wavelength
+
 from .zscan import calc_zchi2_one, calc_zchi2_batch
 
 from .rebin import trapz_rebin
@@ -155,10 +157,10 @@ class Archetype():
         deg_legendre = (coeff!=0.).size-1
         index = np.arange(self._narch)[self._subtype==subtype][0]
 
-        w = np.concatenate([ w for w in dwave.values() ])
-        wave_min = w.min()
-        wave_max = w.max()
-        legendre = np.array([scipy.special.legendre(i)( (wave-wave_min)/(wave_max-wave_min)*2.-1. ) for i in range(deg_legendre)])
+        #w = np.concatenate([ w for w in dwave.values() ])
+        #wave_min = w.min()
+        #wave_max = w.max()
+        legendre = np.array([scipy.special.legendre(i)(reduced_wavelength(w)) for i in range(deg_legendre)])
         binned = trapz_rebin((1+z)*self.wave, self.flux[index], wave)*transmission_Lyman(z,wave,model=self.igm_model)
         flux = np.append(binned[None,:],legendre, axis=0)
         flux = flux.T.dot(coeff).T / (1+z)

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -540,11 +540,6 @@ class DistTargetsDESI(DistTargets):
     def _local_data(self):
         return self._my_data
 
-def none_or_float(value):
-    if value == 'None':
-        return None
-    return float(value)
-
 
 def rrdesi(options=None, comm=None):
     """Estimate redshifts for DESI targets.
@@ -579,8 +574,8 @@ def rrdesi(options=None, comm=None):
     parser.add_argument("--archetype-legendre-percamera", default=True, action="store_true",
         required=False, help="If True, in archetype mode the fitting will be done for each camera/band")
     
-    parser.add_argument("--archetype-legendre-prior", type=none_or_float, default=0.1,
-        required=False, help="sigma to add as prior in solving linear equation, 1/sig**2 will be added, default is 0.1")
+    parser.add_argument("--archetype-legendre-prior", type=float, default=0.1,
+                        required=False, help="sigma to add as prior in solving linear equation, 1/sig**2 will be added, default is 0.1, Note: provide anything <=0 if you do not want to add any prior")
     
     parser.add_argument("--archetypes-no-legendre", default=False, action="store_true",
         required=False, help="Use this flag with archetypes if want to TURN OFF all archetype related default values")
@@ -877,7 +872,7 @@ def rrdesi(options=None, comm=None):
         else:
             if comm_rank == 0 and args.archetypes is not None:
                 print('Will be using default archetype values.') 
-                print('number of minimum redshift for which archetype redshift fitting will be done = %d'%(nminima))
+                print('Number of minimum redshift for which archetype redshift fitting will be done = %d'%(nminima))
 
             if ncamera>1: 
                 archetype_legendre_percamera = True
@@ -893,9 +888,16 @@ def rrdesi(options=None, comm=None):
             else:
                 if comm_rank == 0 and args.archetypes is not None:
                     print('No Legendre polynomial will be added to archetypes.')
-            archetype_legendre_prior = args.archetype_legendre_prior
+            if args.archetype_legendre_prior<=0:
+                archetype_legendre_prior = None
+                printstr = 'no'
+            else:
+                archetype_legendre_prior = args.archetype_legendre_prior
+                printstr = 'a'
             if comm_rank == 0 and args.archetypes is not None:
-                print('archetype_legendre_prior = %s has been provided, so a prior will be added while solving for the coefficients'%(archetype_legendre_prior))
+                if archetype_legendre_prior is None:
+                    print('A zero or negative prior is provided so setting archetype_legendre_prior = None')
+                print('archetype_legendre_prior = %s has been provided, so %s prior will be added while solving for the coefficients'%(archetype_legendre_prior, printstr))
             if args.archetype_nnearest is not None:
                 if comm_rank == 0 and args.archetypes is not None:
                     print('nearest neighbour = %d is provided, will do the final fitting for N-best nearest archetypes in chi2 space..'%(args.archetype_nnearest))

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -540,6 +540,11 @@ class DistTargetsDESI(DistTargets):
     def _local_data(self):
         return self._my_data
 
+def none_or_float(value):
+    if value == 'None':
+        return None
+    return value
+
 
 def rrdesi(options=None, comm=None):
     """Estimate redshifts for DESI targets.
@@ -574,7 +579,7 @@ def rrdesi(options=None, comm=None):
     parser.add_argument("--archetype-legendre-percamera", default=True, action="store_true",
         required=False, help="If True, in archetype mode the fitting will be done for each camera/band")
     
-    parser.add_argument("--archetype-legendre-prior", type=float, default=0.1,
+    parser.add_argument("--archetype-legendre-prior", type=none_or_float, default=0.1,
         required=False, help="sigma to add as prior in solving linear equation, 1/sig**2 will be added, default is 0.1")
     
     parser.add_argument("--archetypes-no-legendre", default=False, action="store_true",
@@ -912,7 +917,7 @@ def rrdesi(options=None, comm=None):
         # refinement.  This function only returns data on the rank 0 process.
 
         start = elapsed(None, "", comm=comm)
-        
+        print(f'prior = {archetype_legendre_prior}')
         scandata, zfit = zfind(targets, dtemplates, mpprocs,
             nminima=nminima, archetypes=args.archetypes,
             priors=args.priors, chi2_scan=args.chi2_scan, use_gpu=use_gpu, zminfit_npoints=args.zminfit_npoints, per_camera=archetype_legendre_percamera, deg_legendre=args.archetype_legendre_degree, n_nearest=args.archetype_nnearest, prior_sigma=archetype_legendre_prior, ncamera=ncamera)

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -543,7 +543,7 @@ class DistTargetsDESI(DistTargets):
 def none_or_float(value):
     if value == 'None':
         return None
-    return value
+    return float(value)
 
 
 def rrdesi(options=None, comm=None):
@@ -662,7 +662,7 @@ def rrdesi(options=None, comm=None):
         args = parser.parse_args()
     else:
         args = parser.parse_args(options)
-
+    
     if args.ncpu is not None:
         print('WARNING: --ncpu is deprecated; use --mp instead')
         args.mp = args.ncpu
@@ -917,7 +917,7 @@ def rrdesi(options=None, comm=None):
         # refinement.  This function only returns data on the rank 0 process.
 
         start = elapsed(None, "", comm=comm)
-        
+         
         scandata, zfit = zfind(targets, dtemplates, mpprocs,
             nminima=nminima, archetypes=args.archetypes,
             priors=args.priors, chi2_scan=args.chi2_scan, use_gpu=use_gpu, zminfit_npoints=args.zminfit_npoints, per_camera=archetype_legendre_percamera, deg_legendre=args.archetype_legendre_degree, n_nearest=args.archetype_nnearest, prior_sigma=archetype_legendre_prior, ncamera=ncamera)

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -917,7 +917,7 @@ def rrdesi(options=None, comm=None):
         # refinement.  This function only returns data on the rank 0 process.
 
         start = elapsed(None, "", comm=comm)
-        print(f'prior = {archetype_legendre_prior}')
+        
         scandata, zfit = zfind(targets, dtemplates, mpprocs,
             nminima=nminima, archetypes=args.archetypes,
             priors=args.priors, chi2_scan=args.chi2_scan, use_gpu=use_gpu, zminfit_npoints=args.zminfit_npoints, per_camera=archetype_legendre_percamera, deg_legendre=args.archetype_legendre_degree, n_nearest=args.archetype_nnearest, prior_sigma=archetype_legendre_prior, ncamera=ncamera)

--- a/py/redrock/fitz.py
+++ b/py/redrock/fitz.py
@@ -106,16 +106,6 @@ def minfit(x, y):
 
     return (x0, xerr, y0, zwarn)
 
-
-
-def legendre_calculate(nleg, dwave):
-    wave = np.concatenate([ w for w in dwave.values() ])
-    wmin = wave.min()
-    wmax = wave.max()
-    legendre = { hs:np.array([scipy.special.legendre(i)( (w-wmin)/(wmax-wmin)*2.) for i in range(nleg)]) for hs, w in dwave.items() }
-
-    return legendre
-
 def prior_on_coeffs(n_nbh, deg_legendre, sigma, ncamera):
     
     """

--- a/py/redrock/targets.py
+++ b/py/redrock/targets.py
@@ -180,9 +180,9 @@ class Target(object):
         if (self._legendre is not None and self.nleg == nleg):
             return self._legendre
         dwave = { s.wavehash:s.wave for s in self.spectra }
-        wave = np.concatenate([ w for w in dwave.values() ])
-        wmin = wave.min()
-        wmax = wave.max()
+        #wave = np.concatenate([ w for w in dwave.values() ])
+        #wmin = wave.min()
+        #wmax = wave.max()
         self._legendre = { hs:np.array([scipy.special.legendre(i)(reduced_wavelength(w)) for i in range(nleg)]) for hs, w in dwave.items() }
         self.nleg = nleg
         if (use_gpu):

--- a/py/redrock/targets.py
+++ b/py/redrock/targets.py
@@ -180,9 +180,6 @@ class Target(object):
         if (self._legendre is not None and self.nleg == nleg):
             return self._legendre
         dwave = { s.wavehash:s.wave for s in self.spectra }
-        #wave = np.concatenate([ w for w in dwave.values() ])
-        #wmin = wave.min()
-        #wmax = wave.max()
         self._legendre = { hs:np.array([scipy.special.legendre(i)(reduced_wavelength(w)) for i in range(nleg)]) for hs, w in dwave.items() }
         self.nleg = nleg
         if (use_gpu):

--- a/py/redrock/targets.py
+++ b/py/redrock/targets.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 import scipy.sparse
 
-from .utils import mp_array, distribute_work
+from .utils import mp_array, distribute_work, reduced_wavelength
 
 from . import constants
 
@@ -183,7 +183,7 @@ class Target(object):
         wave = np.concatenate([ w for w in dwave.values() ])
         wmin = wave.min()
         wmax = wave.max()
-        self._legendre = { hs:np.array([scipy.special.legendre(i)( (w-wmin)/(wmax-wmin)*2.) for i in range(nleg)]) for hs, w in dwave.items() }
+        self._legendre = { hs:np.array([scipy.special.legendre(i)(reduced_wavelength(w)) for i in range(nleg)]) for hs, w in dwave.items() }
         self.nleg = nleg
         if (use_gpu):
             import cupy as cp

--- a/py/redrock/test/test_utils.py
+++ b/py/redrock/test/test_utils.py
@@ -38,6 +38,27 @@ class TestUtils(unittest.TestCase):
         dist = utils.distribute_work(nproc, ids, capacities=capacities)
         self.assertEqual(list(map(len, dist)), [1, 3])
 
+    def test_reduced_wavelength(self):
+        x = utils.reduced_wavelength(np.arange(10))
+        self.assertEqual(x[0], -1.0)
+        self.assertEqual(x[-1], 1.0)
+        x = utils.reduced_wavelength(np.linspace(3600, 5800, 10))
+        self.assertEqual(x[0], -1.0)
+        self.assertEqual(x[-1], 1.0)
+
+        #- even out-of-order non-linear ok
+        x = utils.reduced_wavelength(np.random.uniform(-5, 20, size=100))
+        self.assertEqual(np.min(x), -1.0)
+        self.assertEqual(np.max(x), 1.0)
+
+        #- also works on cupy if installed,
+        #- and answer remains on GPU as a cupy array
+        if cp_available:
+            x = utils.reduced_wavelength(cp.linspace(3600, 5800, 10))
+            self.assertEqual(x[0], -1.0)
+            self.assertEqual(x[-1], 1.0)
+            self.assertTrue(isinstance(x, cp.ndarray))
+
 def test_suite():
     """Allows testing of only this module with the command::
 

--- a/py/redrock/utils.py
+++ b/py/redrock/utils.py
@@ -256,7 +256,7 @@ def reduced_wavelength(wave):
     Args:
         wave (array): wavelength for which reduced wavelengths to be estimated
     Return:
-        reduced wavelength [-1,1] range
+        reduced wavelength in [-1,1] range
     """
     wave = np.asarray(wave)
     wavemax = wave.max()

--- a/py/redrock/utils.py
+++ b/py/redrock/utils.py
@@ -248,3 +248,17 @@ def getGPUCountMPI(comm):
     if comm.rank == 0:
         print("WARNING:  Found {:d} GPUs".format(len(pci_id_list)))
     return len(pci_id_list)
+
+def reduced_wavelength(wave):
+    """function to calculate reduced wavelength arrya for 
+    legendre polynomial in archetype mode, 
+    legendre polynomials are orthogonal in [-1,1]
+    Args:
+        wave (array): wavelength for which reduced wavelengths to be estimated
+    Return:
+        reduced wavelength [-1,1] range
+    """
+    wave = np.asarray(wave)
+    wavemax = wave.max()
+    wavemin = wave.min()
+    return 2*(wave - wavemax) / (wavemax - wavemin) - 1

--- a/py/redrock/utils.py
+++ b/py/redrock/utils.py
@@ -258,7 +258,6 @@ def reduced_wavelength(wave):
     Return:
         reduced wavelength in [-1,1] range
     """
-    wave = np.asarray(wave)
     wavemax = wave.max()
     wavemin = wave.min()
-    return 2*(wave - wavemax) / (wavemax - wavemin) - 1
+    return 2*(wave - wavemin) / (wavemax - wavemin) - 1


### PR DESCRIPTION
Thanks @sbailey for pointing me to the issue of inconsistent legendre wavelength basis definition in code. The issue is detailed in [issue#291](https://github.com/desihub/redrock/issues/291) have now defined a separate utility function `reduced_wavelength()` in `utils.py`, which is called whenever we want to define legendre wavelength basis. It makes the code cleaner and consistent in archetype mode. This consistent definition should also be included in [PR#293](https://github.com/desihub/redrock/pull/293) and [PR#283](https://github.com/desihub/redrock/pull/283).

It also fixes a minor case, when an end user does not want to add a prior in the archetype mode. I have implemented a minor logic, that if `--archetype-legendre-prior` flag is <=0, then no prior will be added in archetype mode.

