### PR TITLE
set max_velo_diff  to 100 km/s for stars

### DIFF
--- a/py/redrock/constants.py
+++ b/py/redrock/constants.py
@@ -5,6 +5,7 @@ redrock.constants
 Set constants used by the rest of the package.
 """
 max_velo_diff = 1000.0  # km/s
+max_velo_diff_star = 100.0  # km/s
 min_resolution_integral = 0.99
 
 min_deltachi2 = 9.

--- a/py/redrock/fitz.py
+++ b/py/redrock/fitz.py
@@ -126,7 +126,8 @@ def prior_on_coeffs(n_nbh, deg_legendre, sigma, ncamera):
     return prior
 
 
-def fitz(zchi2, redshifts, target, template, nminima=3, archetype=None, use_gpu=False, deg_legendre=None, zminfit_npoints=15, per_camera=False, n_nearest=None, prior_sigma=None):
+def fitz(zchi2, redshifts, target, template, nminima=3, archetype=None, use_gpu=False, deg_legendre=None,
+         zminfit_npoints=15, per_camera=False, n_nearest=None, prior_sigma=None):
     """Refines redshift measurement around up to nminima minima.
 
     TODO:
@@ -185,15 +186,20 @@ def fitz(zchi2, redshifts, target, template, nminima=3, archetype=None, use_gpu=
     else:
         nz = zminfit_npoints
 
+    if template.template_type == 'STAR':
+        max_velo_diff = constants.max_velo_diff_star
+    else:
+        max_velo_diff = constants.max_velo_diff
+
     for imin in find_minima(zchi2):
         if len(results) == nminima:
             break
 
-        #- Skip this minimum if it is within constants.max_velo_diff km/s of a
+        #- Skip this minimum if it is within max_velo_diff km/s of a
         # previous one dv is in km/s
         zprev = np.array([tmp['z'] for tmp in results])
         dv = get_dv(z=redshifts[imin],zref=zprev)
-        if np.any(np.abs(dv) < constants.max_velo_diff):
+        if np.any(np.abs(dv) < max_velo_diff):
             continue
 
         #- Sample more finely around the minimum
@@ -304,10 +310,10 @@ def fitz(zchi2, redshifts, target, template, nminima=3, archetype=None, use_gpu=
             zwarn |= ZW.Z_FITLIMIT
 
         #- Skip this better defined minimum if it is within
-        #- constants.max_velo_diff km/s of a previous one
+        #- max_velo_diff km/s of a previous one
         zprev = np.array([tmp['z'] for tmp in results])
         dv = get_dv(z=zbest, zref=zprev)
-        if np.any(np.abs(dv) < constants.max_velo_diff):
+        if np.any(np.abs(dv) < max_velo_diff):
             continue
 
         if archetype is None:

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -210,7 +210,8 @@ def sort_zfit_dict(zfit):
     sort_dict_by_cols(zfit, ('__badfit__', 'chi2'), sort_first_column_first=True)
     zfit.pop('__badfit__')
 
-def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=None, chi2_scan=None, use_gpu=False, zminfit_npoints=15, per_camera=None, deg_legendre=None, n_nearest=None, prior_sigma=None, ncamera=None):
+def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=None, chi2_scan=None, use_gpu=False,
+          zminfit_npoints=15, per_camera=None, deg_legendre=None, n_nearest=None, prior_sigma=None, ncamera=None):
     """Compute all redshift fits for the local set of targets and collect.
 
     Given targets and templates distributed across a set of MPI processes,
@@ -439,6 +440,11 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
                     else:
                         spectype, subtype = parse_fulltype(fulltype)
 
+                if spectype.upper() == 'STAR':
+                    max_velo_diff = constants.max_velo_diff_star
+                else:
+                    max_velo_diff = constants.max_velo_diff
+
                 #Have to create arrays of correct length since using dict of
                 #np arrays instead of astropy Table
                 nmin = len(tmp['chi2'])
@@ -525,8 +531,8 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
             tzfit['znum'] = np.arange(l)
 
             #- calc deltachi2 and set ZW.SMALL_DELTA_CHI2 flag
-            deltachi2, setzwarn = calc_deltachi2(
-                    tzfit['chi2'], tzfit['z'], tzfit['zwarn'])
+            deltachi2, setzwarn = calc_deltachi2(tzfit['chi2'], tzfit['z'], tzfit['zwarn'],
+                                                 dvlimit=max_velo_diff)
             tzfit['deltachi2'] = deltachi2
             tzfit['zwarn'][setzwarn] |= ZW.SMALL_DELTA_CHI2
 


### PR DESCRIPTION
Simple fix for #277.

Use 100 km/s as the "exclusion" zone for identifying "good minima" in the redshift scans for stars, versus 1000 km/s (which remains the same for galaxy and quasar scans).

With this branch, using the example object discussed in #276 and #277, we now get the following minima with the PCA/Jura templates:
```
     targetid               z                     zerr          zwarn        chi2        ... spectype subtype ncoeff znum     deltachi2
----------------- ---------------------- ---------------------- ----- ------------------ ... -------- ------- ------ ---- ------------------
39627688712865504    0.16364439776838893 1.0766243480836462e-05     0  19214.88787150383 ...   GALAXY             10    0  27842.03577605635
39627688712865504    0.17690234647531164  2.692106748341094e-05     0  47056.92364756018 ...   GALAXY             10    1  6043.541360843927
39627688712865504    0.18493315451662629  3.556348128910181e-05     0 53100.465008404106 ...   GALAXY             10    2  9627.262869153048
39627688712865504  0.0015657665423507877 1.1923063512031652e-05     0 62727.727877557154 ...     STAR       K      5    3  21.07149459215725
39627688712865504  0.0007735323930400607 1.0333191156667991e-05     0  62748.79937214931 ...     STAR       K      5    4 49417.100658225216
39627688712865504      1.039699278826281 2.6425853489245436e-05     0 112165.90003037453 ...      QSO     LOZ      4    5  2591.760555922985
39627688712865504     0.5302398868198309  3.203875319557626e-05     0 114757.66058629751 ...      QSO     LOZ      4    6  468.9983800649643
39627688712865504     0.5193319912431936  2.671646591573515e-05     0 115226.65896636248 ...      QSO     LOZ      4    7 15535.551420591131
39627688712865504 -0.0014325498503955333  6.594297818415482e-06     0 130762.21038695361 ...     STAR       M      5    8                0.0
```
And the following minima with an early version of the NMF templates:
```
     targetid               z                     zerr          zwarn        chi2        ... spectype subtype ncoeff znum     deltachi2
----------------- ---------------------- ---------------------- ----- ------------------ ... -------- ------- ------ ---- ------------------
39627688712865504  0.0015657665423507877 1.1923063512031652e-05     0 62727.727877557154 ...     STAR       K      5    0  21.07149459215725
39627688712865504  0.0007735323930400607 1.0333191156667991e-05     0  62748.79937214931 ...     STAR       K      5    1  3646.557508873142
39627688712865504     0.2592844076863871 1.8832468985475416e-05     0  66395.35688102245 ...   GALAXY             10    2 1659.1592923998833
39627688712865504    0.24543019059875015 2.5085768138572075e-05     0  68054.51617342234 ...   GALAXY             10    3 1106.9018910750747
39627688712865504    0.16378398397398541 2.0080150217357837e-05     0  69161.41806449741 ...   GALAXY             10    4 43004.481965877116
39627688712865504      1.039699278826281 2.6425853489245436e-05     0 112165.90003037453 ...      QSO     LOZ      4    5  2279.647886157036
39627688712865504     1.7249275860747917 0.00011775404198232079     0 114445.54791653156 ...      QSO     HIZ      4    6 312.11266976594925
39627688712865504     0.5302398868198309  3.203875319557626e-05     0 114757.66058629751 ...      QSO     LOZ      4    7 16004.549800656096
39627688712865504 -0.0014325498503955333  6.594297818415482e-06     0 130762.21038695361 ...     STAR       M      5    8                0.0
```

The main point here is that the best-fitting STAR redshift (with either set of templates) is now `z=0.0015657` vs `z=-0.001475` previously (i.e., with `main`). (Also note the much smaller delta-chi2 value between the STAR minima.)

In @sbailey's beautifully labeled graphic, the new redshift corresponds to the better / best "first" (i.e., non-bad) redshift minimum:
![image](https://github.com/desihub/redrock/assets/1431820/392e20fa-2336-44f7-bd4d-a7b8a3cde623)

So I think this PR is non-controversial and should be good-to-go.