### PR TITLE
fix max_velo_diff for archetypes

### DIFF
--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -439,7 +439,9 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
                     else:
                         spectype, subtype = parse_fulltype(fulltype)
 
-                if spectype.upper() == 'STAR':
+                # set max_velo_diff differently for STARs, but watch out
+                # for archtypes which have spectype as list instead of scalar
+                if (np.isscalar(spectype) and spectype.upper() == 'STAR') or spectype[0].upper() == 'STAR':
                     max_velo_diff = constants.max_velo_diff_star
                 else:
                     max_velo_diff = constants.max_velo_diff


### PR DESCRIPTION
This PR is a followup to #300 which set max_velo_diff for spectype=STAR differently than GALAXY and QSO, but didn't handle the archetype case where spectype is a list of strings instead of a single string.  This test command used to fail but now passes with this PR:
```
srun -n 4 --gpu-bind=map_gpu:3,2,1,0 --cpu-bind=cores rrdesi_mpi --gpu -n 10 \
  -i $CFS/desi/spectro/redux/iron/tiles/cumulative/80605/20210205/coadd-6-80605-thru20210205.fits \
  --archetypes /global/cfs/cdirs/desi/users/abhijeet/new-archetypes/rrarchetype-galaxy.fits \
  --model $SCRATCH/redrock/rrmodel-test.fits \
  -o $SCRATCH/redrock/redrock-test.fits
```

I also verified that removing the `--archetypes` option and running in non-archetype mode also continues to work.