### PR TITLE
Insist that FITMETHOD is a 4-string from the moment NONE is added

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -14,7 +14,8 @@ redrock Change Log
   fulltype,spectype,subtype parsing (PR `#297`_).
 * Fix warning from zero-sized array (PR `#298`_).
 * Standardize wavelength -> [-1,1] mapping for Legendre poly (PR `#299`_).
-* set max_velo_diff to 100 km/s for stars (PR `#300`_).
+* Set max_velo_diff to 100 km/s for stars (PR `#300`_).
+* Ensure `FITMETHOD` holds 4-string `NONE` (addresses `#301`) (PR `#303`_).
 
 .. _`#290`: https://github.com/desihub/redrock/pull/290
 .. _`#292`: https://github.com/desihub/redrock/pull/292
@@ -24,6 +25,8 @@ redrock Change Log
 .. _`#298`: https://github.com/desihub/redrock/pull/298
 .. _`#299`: https://github.com/desihub/redrock/pull/299
 .. _`#300`: https://github.com/desihub/redrock/pull/300
+.. _`#301`: https://github.com/desihub/redrock/issues/301
+.. _`#303`: https://github.com/desihub/redrock/pull/303
 
 0.19.0 (2024-04-19)
 -------------------

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -1034,6 +1034,8 @@ def rrdesi(options=None, comm=None):
             zfit['spectype'][ii] = 'GALAXY'
             zfit['subtype'][ii] = ''
             zfit['coeff'][ii] = 0.
+            # ADM enforce 4-string in case we've only populated PCA/NMF.
+            zfit['fitmethod'] = zfit['fitmethod'].astype('S4')
             zfit['fitmethod'][ii] = 'NONE'
 
             ii = np.isin(zfit['targetid'], targetids[broken])
@@ -1079,7 +1081,7 @@ def rrdesi(options=None, comm=None):
                         zbest.rename_column(colname, colname.upper())
 
                 # Allow 4 char for ARCH (vs. PCA/NMF) even if archetypes aren't used
-                zbest['FITMETHOD'] = zbest['FITMETHOD'].astype('S4')                
+                zbest['FITMETHOD'] = zbest['FITMETHOD'].astype('S4')
 
                 write_zbest(args.outfile, zbest,
                         targets.fibermap, targets.exp_fibermap,


### PR DESCRIPTION
This PR fixes issue #301 by enforcing that the `FITMETHOD` column can hold strings of length 4 from the moment the string `NONE` is added to the column.

Testing (as compared to the example in [issue 301](https://github.com/desihub/redrock/issues/301#issuecomment-2083288144)):

```
salloc -N 1 -C gpu -A desi_g --gpus-per-node=4 -t 04:00:00 -q interactive

srun -n 4 --gpu-bind=map_gpu:3,2,1,0 --cpu-bind=cores rrdesi_mpi --gpu -n 100 \
  -i $CFS/desi/spectro/redux/iron/tiles/cumulative/80605/20210205/coadd-6-80605-thru20210205.fits \
  --model $SCRATCH/redrock/rrmodel-test.fits \
  -o $SCRATCH/redrock/redrock-test.fits
```
Proceeds without any warning...
```
import fitsio
zcat = fitsio.read('$SCRATCH/redrock/redrock-test.fits', 'REDSHIFTS')
set(zcat['FITMETHOD'])

Out[]: {'NONE', 'PCA'}
```