### PR TITLE
FITMETHOD bytes vs. str

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -1035,7 +1035,7 @@ def rrdesi(options=None, comm=None):
             zfit['subtype'][ii] = ''
             zfit['coeff'][ii] = 0.
             # ADM enforce 4-string in case we've only populated PCA/NMF.
-            zfit['fitmethod'] = zfit['fitmethod'].astype('S4')
+            zfit['fitmethod'] = zfit['fitmethod'].astype('U4')
             zfit['fitmethod'][ii] = 'NONE'
 
             ii = np.isin(zfit['targetid'], targetids[broken])
@@ -1081,7 +1081,7 @@ def rrdesi(options=None, comm=None):
                         zbest.rename_column(colname, colname.upper())
 
                 # Allow 4 char for ARCH (vs. PCA/NMF) even if archetypes aren't used
-                zbest['FITMETHOD'] = zbest['FITMETHOD'].astype('S4')
+                zbest['FITMETHOD'] = zbest['FITMETHOD'].astype('U4')
 
                 write_zbest(args.outfile, zbest,
                         targets.fibermap, targets.exp_fibermap,

--- a/py/redrock/results.py
+++ b/py/redrock/results.py
@@ -49,7 +49,8 @@ def write_zscan(filename, zscan, zfit, clobber=False):
     #- convert unicode to byte strings
     for colname in ('spectype', 'subtype', 'fitmethod'):
         if colname in zfit.columns:
-            zfit.replace_column(colname, np.char.encode(zfit[colname], 'ascii'))
+            if zfit[colname].dtype.kind == 'U':
+                zfit.replace_column(colname, np.char.encode(zfit[colname], 'ascii'))
 
     zbest = zfit[zfit['znum'] == 0]
     zbest.remove_column('znum')


### PR DESCRIPTION
This PR is a followup to #303 which broke the ability to write the rrdetails HDF5 file, due to a str-vs-bytes issue on the FITMETHOD column.  Forcing FITMETHOD to `.astype('S4')` left the FITMETHOD column as bytes while the SPECTYPE and SUBTYPE columns were unicode strings.  Writing to the fits file worked fine because astropy.io.fits is forgiving about bytes vs. str, but h5py is not and we tripped over our attempt to standardize it for h5py `np.char.encode(zfit[colname], 'ascii')`.

This fix is two-fold:
* use `.astype('U4')` instead of `.astype('S4')` so that FITMETHOD is a str column just like SPECTYPE and SUBTYPE
* while writing the hdf5 file, first check if a unicode-to-bytes conversion is needed before trying to convert a column.

Either fix alone would have been sufficient; including both helps us be more future proof to other bytes-vs-str bugs.

I'm going to self-merge this so that I can proceed with Jura testing (otherwise zproc jobs are crashing when using redrock/main)