### PR TITLE
remove unnecessary desispec dependency

### DIFF
--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -22,8 +22,6 @@ from .igm import transmission_Lyman
 from .rebin import rebin_template, trapz_rebin
 from .zscan import spectral_data
 
-from desispec.coaddition import coadd_cameras
-
 valid_template_methods = ('PCA', 'NMF')
 
 class Template(object):


### PR DESCRIPTION
fixes #305 by removing unnecessary and unused desispec dependency.

@amolaeinezhad please check if this is sufficient or if other extraneous dependencies have crept into the core code.