### PR TITLE
more MPI memory management on large inputs

### DIFF
--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -425,7 +425,7 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
         # Ranks>0 send results to rank 0
         # first send num_batches (int), and then the batches of results (dict)
         else:
-            max_targets_per_send = 5
+            max_targets_per_send = 5000
             if len(results) < max_targets_per_send:
                 targets.comm.send(1, dest=0)
                 targets.comm.send(results, dest=0)

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -403,15 +403,43 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
     allzfit = None
 
     if targets.comm is not None:
-        # gather can fail with especially large inputs, so use point-to-point
+        # gather failes with results>2GB, so use point-to-point instead
         ### results = targets.comm.gather(results, root=0)
+
+        # Rank 0 receives results in batches from each of the other ranks;
+        # this preserves the same order as comm.gather
         if targets.comm.rank == 0:
             results = [results,]
             for other_rank in range(1,targets.comm.size):
-                other_results = targets.comm.recv(source=other_rank, tag=42)
+
+                # first get the number of batches expected
+                num_batches = targets.comm.recv(source=other_rank, tag=40)
+
+                # then collect those batches
+                other_results = dict()
+                for i in range(num_batches):
+                    other_results.update( targets.comm.recv(source=other_rank, tag=42+i) )
+
                 results.append(other_results)
+
+        # Ranks>0 send results to rank 0
+        # first send num_batches (int), and then the batches of results (dict)
         else:
-            targets.comm.send(results, dest=0, tag=42)
+            max_targets_per_send = 5000
+            if len(results) < max_targets_per_send:
+                targets.comm.send(1, dest=0, tag=40)
+                targets.comm.send(results, dest=0, tag=42)
+            else:
+                # first send the number of batches that will be sent
+                num_batches = (len(results)-1) // max_targets_per_send + 1
+                targets.comm.send(num_batches, dest=0, tag=40)
+
+                # split into (targetid, values) items for dict "slicing"
+                result_items = list(results.items())
+                ### for i in range(0, len(results), max_targets_per_send):
+                for i in range(num_batches):
+                    subresults = dict(result_items[i*max_targets_per_send:(i+1)*max_targets_per_send])
+                    targets.comm.send(subresults, dest=0, tag=42+i)
 
         targets.comm.barrier()
     else:

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -413,33 +413,32 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
             for other_rank in range(1,targets.comm.size):
 
                 # first get the number of batches expected
-                num_batches = targets.comm.recv(source=other_rank, tag=40)
+                num_batches = targets.comm.recv(source=other_rank)
 
                 # then collect those batches
                 other_results = dict()
-                for i in range(num_batches):
-                    other_results.update( targets.comm.recv(source=other_rank, tag=42+i) )
+                for _ in range(num_batches):
+                    other_results.update( targets.comm.recv(source=other_rank) )
 
                 results.append(other_results)
 
         # Ranks>0 send results to rank 0
         # first send num_batches (int), and then the batches of results (dict)
         else:
-            max_targets_per_send = 5000
+            max_targets_per_send = 5
             if len(results) < max_targets_per_send:
-                targets.comm.send(1, dest=0, tag=40)
-                targets.comm.send(results, dest=0, tag=42)
+                targets.comm.send(1, dest=0)
+                targets.comm.send(results, dest=0)
             else:
                 # first send the number of batches that will be sent
                 num_batches = (len(results)-1) // max_targets_per_send + 1
-                targets.comm.send(num_batches, dest=0, tag=40)
+                targets.comm.send(num_batches, dest=0)
 
                 # split into (targetid, values) items for dict "slicing"
                 result_items = list(results.items())
-                ### for i in range(0, len(results), max_targets_per_send):
-                for i in range(num_batches):
-                    subresults = dict(result_items[i*max_targets_per_send:(i+1)*max_targets_per_send])
-                    targets.comm.send(subresults, dest=0, tag=42+i)
+                for i in range(0, len(results), max_targets_per_send):
+                    subresults = dict(result_items[i:i+max_targets_per_send])
+                    targets.comm.send(subresults, dest=0)
 
         targets.comm.barrier()
     else:


### PR DESCRIPTION
This PR makes 3 updates to help with MPI memory management on especially large inputs like jura special-other healpix 27257 with 33749 targets (!):
  * when broadcasting the large RESOLUTION HDUs, break into chunks to avoid 2 GB per-bcast limit
  * when collecting results, break into chunks to avoid 2 GB per-send limit
    * this is a followup to PR #310 which worked up to ~20k targets, but not ~30k
  * if the input communicator is larger than needed, split it into a sub communicator with just the ranks that will be use to avoid unnecessary bcasts to unused ranks

I verified on main/dark healpix 0 that the outputs are the same as main, whether the chunks are big or small.  A final test on special-other healpix 27257 is still running; I will confirm that succeeded before merging, but I wanted to get this PR in while that was running.
