### PR TITLE
Clean-up environment variables moved to desimodules

### DIFF
--- a/etc/redrock.module
+++ b/etc/redrock.module
@@ -76,9 +76,3 @@ setenv [string toupper $product] $PRODUCT_DIR
 #
 # Add any non-standard Module code below this point.
 #
-# MPI or multiprocessing handle parallelism, not OpenMP via numpy/MKL
-#
-setenv KMP_AFFINITY disabled
-setenv MPICH_GNI_FORK_MODE FULLCOPY
-setenv OMP_NUM_THREADS 1
-setenv HDF5_USE_FILE_LOCKING FALSE

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Based on desimodules/22.2.
+numpy<2.0
 astropy
 scipy
 h5py


### PR DESCRIPTION
This PR cleans up environment variables that are now defined in desimodules as of desihub/desimodules#52.