### PR TITLE
also write header keywords to REDSHIFTS HDU

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -107,8 +107,10 @@ def write_zbest(outfile, zbest, fibermap, exp_fibermap, tsnr2,
 
     Modifies input tables.meta['EXTNAME']
     """
+    # header keywords for both PRIMARY and REDSHIFTS HDU
     header = _get_header(templates, archetypes, spec_header)
 
+    zbest.meta.update(header)
     zbest.meta['EXTNAME'] = 'REDSHIFTS'
     fibermap.meta['EXTNAME'] = 'FIBERMAP'
     exp_fibermap.meta['EXTNAME'] = 'EXP_FIBERMAP'


### PR DESCRIPTION
This PR fixes #308 by propagating keywords to the REDSHIFTS HDU in addition to the primary/0 HDU.  In particular, by including the TEMNAMnn / TEMVERnn keywords, this enables:
```
from astropy.table import Table
from redrock.templates import load_templates_from_header

zcat = Table.read('redrock-hdrtest.fits', 'REDSHIFTS')
templates = load_templates_from_header(zcat.meta)
```

I tested this with
```
# redrock main
srun -n 4 --gpu-bind=map_gpu:3,2,1,0 --cpu-bind=cores rrdesi_mpi --gpu -n 100 \
  -i $CFS/desi/spectro/redux/jura/tiles/cumulative/80605/20210205/coadd-6-80605-thru20210205.fits \
  -o $SCRATCH/redrock/redrock-main.fits

# redrock this branch
srun -n 4 --gpu-bind=map_gpu:3,2,1,0 --cpu-bind=cores rrdesi_mpi --gpu -n 100 \
  -i $CFS/desi/spectro/redux/jura/tiles/cumulative/80605/20210205/coadd-6-80605-thru20210205.fits \
  -o $SCRATCH/redrock/redrock-hdrtest.fits

fitsdiff /pscratch/sd/s/sjbailey/redrock/redrock-main.fits /pscratch/sd/s/sjbailey/redrock/redrock-hdrtest.fits
```

The data are identical, and the header keywords only differ by new keywords in the REDSHIFTS HDU, and harmless changes like the DATASUM comment timestamp.  I also explicitly verified that the redrock-hdrtest.fits REDSHIFTS HDU now works with `load_templates_from_header` and that the redrock-main.fits file does not.

Note: for older files, `load_templates_from_header` works with the header from HDU 0 of redrock output; this is just a convenience update so that reading the REDSHIFTS table also brings along a header with sufficient information to be able to read the matching set of templates.