### PR TITLE
support rrdesi --templates (list of templates)

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -660,7 +660,7 @@ def rrdesi(options=None, comm=None):
     parser = argparse.ArgumentParser(description="Estimate redshifts from"
         " DESI target spectra.")
 
-    parser.add_argument("-t", "--templates", type=str, default=None,
+    parser.add_argument("-t", "--templates", type=str, nargs='+', default=None,
         required=False, help="template file or directory")
 
     parser.add_argument("--archetypes", type=str, default=None,

--- a/py/redrock/fitz.py
+++ b/py/redrock/fitz.py
@@ -347,7 +347,14 @@ def fitz(zchi2, redshifts, target, template, nminima=3, archetype=None, use_gpu=
     ii = np.argsort([tmp['chi2'] for tmp in results])
     results = [results[i] for i in ii]
 
-    assert len(results) > 0
+    if len(results) == 0:
+        #- Return blank arrays of 0 minima
+        xfloat = np.zeros((0,1), dtype=float)
+        xint = np.zeros((0,1), dtype=int)
+        xstr = np.zeros((0,1), dtype=str)
+        return dict(z=xfloat, zerr=xfloat, zwarn=xint, chi2=xfloat, zz=xfloat, zzchi2=xfloat,
+                    coeff=xfloat, fitmethod=xstr, npixels=xint)
+
     #- Convert list of dicts -> Table
     #from astropy.table import Table
     #results = Table(results)

--- a/py/redrock/priors.py
+++ b/py/redrock/priors.py
@@ -114,6 +114,9 @@ class Priors():
 
         prior = np.where(np.abs(z - z0) < s0/2, 0., np.NaN)
 
+        if np.all(np.isnan(prior)):
+            return prior
+
         index_left, index_right = np.argwhere(prior>=0.0)[0], np.argwhere(prior>=0.0)[-1]
 
         if index_left == 0:

--- a/py/redrock/templates.py
+++ b/py/redrock/templates.py
@@ -298,12 +298,15 @@ def make_fulltype(spectype, subtype):
 def find_templates(template_path=None):
     """Return list of Redrock template files
 
-    `template_path` can be one of 4 things:
+    `template_path` can be one of 5 things:
 
+       * None (use $RR_TEMPLATE_DIR instead)
+       * list/tuple/set/array of template files
        * path to directory containing template files
        * path to single template file to use
        * path to text file listing which template files to use
-       * None (use $RR_TEMPLATE_DIR instead)
+
+    Returns list of template files to use
     """
     if template_path is None:
         if 'RR_TEMPLATE_DIR' in os.environ:
@@ -318,6 +321,11 @@ def find_templates(template_path=None):
         raise IOError("ERROR: can't find template_path, $RR_TEMPLATE_DIR, or {rrcode}/templates/")
     else:
         print(f'DEBUG: Reading templates from {template_path}')
+
+    # for symmetry with load_templates(template_path), also
+    # support list/tuple/etc of strings and just return that
+    if isinstance(template_path, (list, tuple, set, np.ndarray)):
+        return template_path
 
     if os.path.isdir(template_path):
         default_templates_file = f'{template_path}/templates-default.txt'

--- a/py/redrock/test/test_templates.py
+++ b/py/redrock/test/test_templates.py
@@ -81,6 +81,11 @@ class TestTemplates(unittest.TestCase):
         for filename in templates:
             self.assertIn(os.path.basename(filename), self.default_templates)
 
+        # find templates also accepts a list of templates which it just returns
+        t2 = find_templates(templates[1:3])
+        self.assertListEqual(t2, templates[1:3])
+
+        # or read from text file a set of alternate templates
         templates = find_templates(self.testTemplateDir+'/templates-alternate.txt')
 
         # works without a path prefix

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -487,6 +487,10 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
                 #np arrays instead of astropy Table
                 nmin = len(tmp['chi2'])
 
+                if nmin == 0:
+                    print(f'WARNING: no {fulltype} chi2 vs. z minima for targetid {tid}')
+                    continue
+
                 if np.isscalar(spectype):
                     tmp['spectype'] = np.full((nmin, 1), spectype)
                     tmp['subtype'] = np.full((nmin, 1), subtype)
@@ -551,7 +555,7 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
                                 ibad[k]=False
 
                 tzfit['zwarn'][ibad] |= ZW.NEGATIVE_MODEL
-            
+
             tzfit['zwarn'][ tzfit['npixels']==0 ] |= ZW.NODATA
             tzfit['zwarn'][ (tzfit['npixels']<10*tzfit['ncoeff']) ] |= \
                 ZW.LITTLE_COVERAGE


### PR DESCRIPTION
This PR adds support for `rrdesi --templates ...` to accept a list of templates, instead of previously only accepting a single template or a path to a text file with a list of templates.  The intended use case is for the DESI QuasarNet afterburner which filters the template files down to just QSO templates and then wants to run redrock with just those.  It could also be useful in the future for e.g. DESI-2 running with LAE/LBG templates vs. standard galaxy+QSO+star templates, etc.

Alternatively, we could have added a templates-default-qso.txt file to the redrock-templates repo have have the QN afterburner use that.  That would also work (and is still compatible with this PR), but it becomes a bit more of a maintenance headache when making tags and also needing to make templates-X.Y-qso.txt, and when updating QSO templates and needing to update multiple templates-*.txt files.

I updated the test to include this new functionality, and also tested with
```
srun -n 4 --gpu-bind=map_gpu:3,2,1,0 --cpu-bind=cores rrdesi_mpi --gpu -i coadd-0-100-thru20210505.fits -o $SCRATCH/temp/redrock.fits --templates $RR_TEMPLATE_DIR/rrtemplate-QSO-LOZ-v1.0.fits $RR_TEMPLATE_DIR/rrtemplate-QSO-HIZ-v1.1.fits
```
with output in
```
/pscratch/sd/s/sjbailey/temp/redrock.fits
```
confirming that it only used QSO templates (which was also clear from the logs):
```
[login33 20210505] fitsheader -e 0 /pscratch/sd/s/sjbailey/temp/redrock.fits | grep ^TEM
TEMNAM00= 'QSO:::LOZ'                                                           
TEMVER00= '1.0     '                                                            
TEMFIL00= 'rrtemplate-QSO-LOZ-v1.0.fits'                                        
TEMNAM01= 'QSO:::HIZ'                                                           
TEMVER01= '1.1     '                                                            
TEMFIL01= 'rrtemplate-QSO-HIZ-v1.1.fits'                                        
```

Changes still need to be made on the desispec side to use this, but this adds the feature.