### PR TITLE
install_redrock_templates script

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,8 +38,9 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                curl -L https://github.com/desihub/redrock-templates/archive/${RR_TEMPLATE_VER}.tar.gz | tar -x -z -v -C py/redrock
-                /bin/mv py/redrock/redrock-templates-${RR_TEMPLATE_VER} py/redrock/data/templates
+                PYTHONPATH=$(pwd)/py:$PYTHONPATH PATH=$(pwd)/bin:$PATH install_redrock_templates -v ${RR_TEMPLATE_VER}
+                ### curl -L https://github.com/desihub/redrock-templates/archive/${RR_TEMPLATE_VER}.tar.gz | tar -x -z -v -C py/redrock
+                ### /bin/mv py/redrock/redrock-templates-${RR_TEMPLATE_VER} py/redrock/data/templates
 
             - name: Run the test
               run: pytest
@@ -71,8 +72,9 @@ jobs:
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                curl -L https://github.com/desihub/redrock-templates/archive/${RR_TEMPLATE_VER}.tar.gz | tar -x -z -v -C py/redrock
-                /bin/mv py/redrock/redrock-templates-${RR_TEMPLATE_VER} py/redrock/data/templates
+                PYTHONPATH=$(pwd)/py:$PYTHONPATH PATH=$(pwd)/bin:$PATH install_redrock_templates -v ${RR_TEMPLATE_VER}
+                ### curl -L https://github.com/desihub/redrock-templates/archive/${RR_TEMPLATE_VER}.tar.gz | tar -x -z -v -C py/redrock
+                ### /bin/mv py/redrock/redrock-templates-${RR_TEMPLATE_VER} py/redrock/data/templates
             - name: Run the test with coverage
               run: pytest --cov
             - name: Coveralls

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,7 +39,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 curl -L https://github.com/desihub/redrock-templates/archive/${RR_TEMPLATE_VER}.tar.gz | tar -x -z -v -C py/redrock
-                /bin/mv py/redrock/redrock-templates-${RR_TEMPLATE_VER} py/redrock/templates
+                /bin/mv py/redrock/redrock-templates-${RR_TEMPLATE_VER} py/redrock/data/templates
 
             - name: Run the test
               run: pytest
@@ -72,7 +72,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 curl -L https://github.com/desihub/redrock-templates/archive/${RR_TEMPLATE_VER}.tar.gz | tar -x -z -v -C py/redrock
-                /bin/mv py/redrock/redrock-templates-${RR_TEMPLATE_VER} py/redrock/templates
+                /bin/mv py/redrock/redrock-templates-${RR_TEMPLATE_VER} py/redrock/data/templates
             - name: Run the test with coverage
               run: pytest --cov
             - name: Coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__
 htmlcov
 .coverage
 
+# in-place installed templates
+py/redrock/data/templates
+
 # Sphinx
 doc/api
 doc/_build

--- a/bin/install_redrock_templates
+++ b/bin/install_redrock_templates
@@ -23,7 +23,7 @@ def main():
 
     #- Don't get confused by previously defined $RR_TEMPLATE_DIR
     if 'RR_TEMPLATE_DIR' in os.environ:
-        print('WARNING: ignoring $RR_TEMPLATE_DIR; use --outdir to force a specific location instead')
+        print('WARNING: ignoring $RR_TEMPLATE_DIR; use --outdir to force a specific location if needed')
         del os.environ['RR_TEMPLATE_DIR']
 
     #- Check if the output directory already exists

--- a/bin/install_redrock_templates
+++ b/bin/install_redrock_templates
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+"""
+Install Redrock templates into the code directory so that they can be used
+without $RR_TEMPLATE_DIR being set
+"""
+
+import os
+import sys
+import importlib
+import subprocess
+import argparse
+
+import redrock.templates
+
+def main():
+    parser = argparse.ArgumentParser(description="install Redrock templates")
+    parser.add_argument('-v', '--version', default='main', help="Template version(tag) to install")
+    parser.add_argument('--template-url', default='https://github.com/desihub/redrock-templates',
+                        help="URL of GitHub repository with redrock templates")
+    parser.add_argument('-o', '--outdir', help="output directory (default install with redrock code)")
+    args = parser.parse_args()
+
+    #- Don't get confused by previously defined $RR_TEMPLATE_DIR
+    if 'RR_TEMPLATE_DIR' in os.environ:
+        print('WARNING: ignoring $RR_TEMPLATE_DIR; use --outdir to force a specific location instead')
+        del os.environ['RR_TEMPLATE_DIR']
+
+    #- Check if the output directory already exists
+    templatedir = redrock.templates.get_template_dir(args.outdir)
+    if os.path.exists(templatedir):
+        print(f'ERROR: {templatedir} already exists; remove then rerun')
+        return 1
+
+    #- GitHub doesn't require '.git', but other git servers might
+    if not args.template_url.endswith('.git'):
+        args.template_url += '.git'
+
+    #- full clone for main, depth 1 for other tags/branches
+    if args.version == 'main':
+        gitcmd = f"git clone {args.template_url} {templatedir}"
+    else:
+        gitcmd = f"git clone --depth 1 --branch {args.version} {args.template_url} {templatedir}"
+
+    #- Proceed with installing
+    print(f'Installing redrock-templates/{args.version} to {templatedir}')
+    print(gitcmd)
+    p = subprocess.run(gitcmd.split(), capture_output=True)
+    if p.returncode != 0:
+        if len(p.stdout)>0:
+            print(p.stdout.decode())   #- .decode because it is bytes not str
+        if len(p.stderr)>0:
+            print(p.stderr.decode())
+
+        print('ERROR: failed to install redrock-templates/{args.version}')
+        return p.returncode
+
+    #- Check that the installation worked
+    print('Checking that the installed templates work')
+    if args.outdir is not None:
+        os.environ['RR_TEMPLATE_DIR'] = templatedir
+    templates = redrock.templates.load_templates()
+    assert len(templates) > 0
+    print('SUCCESS')
+
+    if args.outdir is not None:
+        print(f'Remember to set $RR_TEMPLATE_DIR={templatedir} before running Redrock')
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bin/install_redrock_templates
+++ b/bin/install_redrock_templates
@@ -15,10 +15,12 @@ import redrock.templates
 
 def main():
     parser = argparse.ArgumentParser(description="install Redrock templates")
-    parser.add_argument('-v', '--version', default='main', help="Template version/tag/branch to install (default %(default)s)")
+    parser.add_argument('-v', '--version', default='main',
+                        help="Template version/tag/branch to install (default %(default)s)")
     parser.add_argument('--template-url', default='https://github.com/desihub/redrock-templates',
                         help="URL of repository with redrock templates (default %(default)s)")
-    parser.add_argument('-o', '--outdir', help="output directory (default install with redrock code)")
+    parser.add_argument('-o', '--outdir',
+                        help="write template files into this directory instead of into the code installation")
     args = parser.parse_args()
 
     #- Don't get confused by previously defined $RR_TEMPLATE_DIR

--- a/bin/install_redrock_templates
+++ b/bin/install_redrock_templates
@@ -15,9 +15,9 @@ import redrock.templates
 
 def main():
     parser = argparse.ArgumentParser(description="install Redrock templates")
-    parser.add_argument('-v', '--version', default='main', help="Template version(tag) to install")
+    parser.add_argument('-v', '--version', default='main', help="Template version/tag/branch to install (default %(default)s)")
     parser.add_argument('--template-url', default='https://github.com/desihub/redrock-templates',
-                        help="URL of GitHub repository with redrock templates")
+                        help="URL of repository with redrock templates (default %(default)s)")
     parser.add_argument('-o', '--outdir', help="output directory (default install with redrock code)")
     args = parser.parse_args()
 

--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -32,7 +32,7 @@ from ..utils import elapsed, get_mp, distribute_work, getGPUCountMPI
 
 from ..targets import (Spectrum, Target, DistTargets)
 
-from ..templates import load_dist_templates
+from ..templates import load_dist_templates, get_template_dir
 
 from ..results import write_zscan
 
@@ -78,6 +78,10 @@ def _get_header(templates, archetypes=None, spec_header=None):
     for key in ['RR_TEMPLATE_DIR', 'RR_ARCHETYPE_DIR']:
         if key in os.environ:
             setdep(header, key, os.environ[key])
+
+    setdep(header, 'RR_TEMPLATE_DIR', get_template_dir())
+    if 'RR_ARCHETYPE_DIR' in os.environ:
+        setdep(header, 'RR_ARCHETYPE_DIR', os.environ['RR_ARCHETYPE_DIR'])
 
     if spec_header is not None:
         for key in ('SPGRP', 'SPGRPVAL', 'TILEID', 'SPECTRO', 'PETAL',


### PR DESCRIPTION
This PR adds an `install_redrock_templates` script, similar in spirit to the `install_desimodel_data` script in desihub/desimodel#179.  This new script installs the Redrock templates to the code data/templates directory.  If `$RR_TEMPLATE_DIR` is set it will be used, but if it is not set then the templates installed into the code directory will be used.  This enables users to install redrock + templates and then not have to also set `$RR_TEMPLATE_DIR`, but that envvar remains available to point Redrock to custom sets of templates if needed.

I'm not suggesting any operational change to how we install and use redrock+templates at NERSC, but this simplifies work on laptops and for end-users, e.g. for tutorials.

## Details

Redrock previously had partial support for default templates installed in `py/redrock/templates`.  I expanded this support and moved the location to `py/redrock/data/templates` to go along with other data and to avoid ambiguity with `py/redrock/templates.py`.

I added a function `redrock.templates.get_template_dir` to standardize the parsing of whether `$RR_TEMPLATE_DIR` is set and where to find the default templates if needed.

Option `--version` can be used to specify a specific tag or branch; default main.  Main is installed as a full git clone so that it can be updated again in the future if needed; tags are installed with `--depth 1` to get just that tag without the rest of the history.

Option `--template-url` can override `https://github.com/desihub/redrock-templates`, e.g. if someone wants to point to their own fork or template repo.

Option `--outdir` can be used to specify a different output directory.

## Testing

In addition to the updated unit tests, I checked this by running `install_redrock_templates` for my copy of Redrock and then running rrdesi_mpi with and without `$RR_TEMPLATE_DIR` set.
```
srun -n 4 -c 32 --gpu-bind=map_gpu:3,2,1,0 --cpu-bind=cores \
    rrdesi_mpi --gpu \
    -i $CFS/desi/spectro/redux/loa/tiles/cumulative/1000/20210517/coadd-0-*.fits \
    -o $SCRATCH/desi/redrock/redrock-with-RR_TEMPLATE_DIR.fits > $SCRATCH/desi/redrock/rrlog-with-RR_TEMPLATE_DIR.log

unset RR_TEMPLATE_DIR

srun -n 4 -c 32 --gpu-bind=map_gpu:3,2,1,0 --cpu-bind=cores \
    rrdesi_mpi --gpu \
    -i $CFS/desi/spectro/redux/loa/tiles/cumulative/1000/20210517/coadd-0-*.fits \
    -o $SCRATCH/desi/redrock/redrock-no-RR_TEMPLATE_DIR.fits > $SCRATCH/desi/redrock/rrlog-no-RR_TEMPLATE_DIR.log
```
Outputs in /pscratch/sd/s/sjbailey/desi/redrock show the the only differences are header timestamps and the keywords recording the templates location; the data are bitwise identical.