### PR TITLE
use single precision for outputs; update readers

### DIFF
--- a/py/redrock/test/test_io.py
+++ b/py/redrock/test/test_io.py
@@ -7,7 +7,7 @@ from uuid import uuid1
 import numpy as np
 
 from .. import utils as rrutils
-from ..results import read_zscan, write_zscan
+from ..results import read_zscan, write_zscan, read_zfit
 from ..zfind import zfind
 from ..templates import DistTemplate
 
@@ -83,5 +83,50 @@ class TestIO(unittest.TestCase):
                 self.assertEqual(len(zz['redshifts']), len(zz['zchi2']))
                 self.assertGreater(len(zz['zfit']), 0, f'Empty zfit Table for {targetid=} {fulltype=}')
 
+        #- targetid subsets
+        targetids = np.unique(zfit['targetid'])
+
+        zscan, zfit = read_zscan(zscanfile, select_targetids=targetids[1])
+        self.assertEqual(len(np.unique(zfit['targetid'])), 1)
+        self.assertEqual(np.unique(zfit['targetid'])[0], targetids[1])
+
+        zscan, zfit = read_zscan(zscanfile, select_targetids=targetids[0:2])
+        self.assertEqual(len(np.unique(zfit['targetid'])), 2)
+        self.assertTrue(np.all(np.unique(zfit['targetid']) == targetids[0:2]))
+
+        #- UPPERCASE column names
+        zscan, zfit = read_zscan(zscanfile, upper=True)
+        self.assertIn('TARGETID', zfit.colnames)
+
+        #- only zscan; not (zscan,zfit)
+        results = read_zscan(zscanfile, nozfit=True)
+        self.assertTrue(isinstance(results, dict))  #- not tuple
+        self.assertIn(targetids[0], results.keys())
+
+    def test_read_zfit(self):
+        """Test read_zfit with pre-generated data"""
+        import importlib
+        filename = importlib.resources.files('redrock.test').joinpath('data/rrdetails-test.h5')
+        zfit = read_zfit(filename)
+        targetids = np.unique(zfit['targetid'])
+        self.assertEqual(len(targetids), 3)
+
+        #- Select two targetids
+        zfit2 = read_zfit(filename, select_targetids=targetids[0:2])
+        targetids2 = np.unique(zfit2['targetid'])
+        self.assertEqual(len(targetids2), 2)
+        self.assertTrue(np.all(targetids2 == targetids[0:2]))
+
+        #- Select a single targetid as integer
+        zfit1 = read_zfit(filename, select_targetids=targetids[1])
+        targetids1 = np.unique(zfit1['targetid'])
+        self.assertEqual(len(targetids1), 1)
+        self.assertEqual(targetids1[0], targetids[1])
+
+        #- force column names to UPPERCASE
+        zfit = read_zfit(filename, upper=True)
+        self.assertIn('TARGETID', zfit.colnames)
+        self.assertIn('Z', zfit.colnames)
+        self.assertNotIn('z', zfit.colnames)
 
 

--- a/py/redrock/test/test_io.py
+++ b/py/redrock/test/test_io.py
@@ -61,13 +61,22 @@ class TestIO(unittest.TestCase):
         zscan2, zfit2 = read_zscan(self.testfile)
 
         self.assertEqual(zfit1.colnames, zfit2.colnames)
+
+        #- z and targetid retain original precision/size; others may have lower precision
+        self.assertEqual(zfit1['z'].dtype, zfit2['z'].dtype)
+        self.assertEqual(zfit1['targetid'].dtype, zfit2['targetid'].dtype)
+
         for cn in zfit1.colnames:
-            np.testing.assert_equal(zfit1[cn], zfit2[cn])
+            d2 = zfit2[cn]
+            d1 = zfit1[cn].astype(d2.dtype)  #- e.g. float64 -> float32
+            np.testing.assert_equal(d1, d2)
 
         for targetid in zscan1:
             for spectype in zscan1[targetid]:
                 for key in zscan1[targetid][spectype]:
                     d1 = zscan1[targetid][spectype][key]
+                    if key != 'redshifts':
+                        d1 = d1.astype(np.float32)
                     d2 = zscan2[targetid][spectype][key]
                     self.assertTrue(np.all(d1==d2), 'data mismatch {}/{}/{}'.format(targetid, spectype, key))
 


### PR DESCRIPTION
This PR makes several changes for Redrock I/O:
  * Update `redrock.results.read_zscan` for reading rrdetails files
    * ~7x faster by refactoring how the zfit tables are parsed
    * add option `nozfit=True` to return just the chi2 vs. z (zscan) results, not including the zfit tables
  * Add `redrock.results.read_zfit` to read+stack the Nth best fit zfit tables
  * Both `read_zscan` and `read_zfit`
    * add option `upper=True` to force columns to UPPERCASE like most DESI files
    * update `select_targetids` to accept a single integer in addition to list/arrays of integers
  * Fix bug where zbest table in rrdetails output was accidentally written then discarded
  * Change rrdetails output precision to single precision float and smaller integers to save disk space
     * zerr, chi2, zz, zzchi2, coeff, deltachi2: float64 -> float32
     * zwarn, npixels: int64 -> int32
     * znum, ncoeff: int64 -> int8

The output precision change was motivated by deishub/desispec#2456 suggesting to use smaller redshift steps in zscan, in which case the rrdetails files were getting rather large.  With this update, smaller steps in the galaxy scan results in files with the same size as before.

I did *not* change the precision of the outputs in the redrock*.fits table.  I think we should do that too, but since those are used more and propagate into the final redshift tables for a production, I wanted to get a second opinion before making that update.

Example outputs in /pscratch/sd/s/sjbailey/desi/redrock/io, with originals in the loa subdirectory:
```
<perlmutter io> ls -lh *.* loa/*.*
-r--r----- 1 sjbailey desi 214M Mar 28 16:27 loa/coadd-2-1263-thru20240212.fits
-r--r----- 1 sjbailey desi 493K Mar 28 16:27 loa/redrock-2-1263-thru20240212.fits
-r--r----- 1 sjbailey desi 132M Mar 28 16:28 loa/rrdetails-2-1263-thru20240212.h5
-rw-r--r-- 1 sjbailey desi 493K Mar 28 16:30 redrock-2-1263-thru20240212-float32.fits
-rw-r--r-- 1 sjbailey desi  67M Mar 28 16:30 rrdetails-2-1263-thru20240212-float32.h5
```

fitsdiff confirms that redrock-2-1263-thru20240212-float32.fits and loa/redrock-2-1263-thru20240212.fits are still identical except for headers (though I suggest we downgrade the precision of some of the redrock columns).

rrdetails-2-1263-thru20240212-float32.h5 is 2x smaller than the original loa file.

a gotcha for consideration: currently redrock uses zchi2=9e+99 for the chi2 of a complete failed fit, which gets converted into inf for float32.  That could be a pain, and we should consider using a smaller placeholder value for float32 chi2 of fit failures (e.g. 3e33).

```
import h5py

h1 = h5py.File('loa/rrdetails-2-1263-thru20240212.h5')
h2 = h5py.File('rrdetails-2-1263-thru20240212-float32.h5')

zchi2_orig = h1['zscan']['GALAXY']['zchi2'][:]
zchi2_new = h2['zscan']['GALAXY']['zchi2'][:]
print(zchi2_orig.dtype, zchi2_new.dtype)
print(np.all(zchi2_orig.astype(np.float32) == zchi2_new))
ii = np.isfinite(zchi2_new)
print(np.std(zchi2_new[ii] - zchi2_orig[ii]))
```
results
```
float64 float32
True
0.00036350274545413297
```