### PR TITLE
native_endian fix for numpy 2.x

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,8 +38,8 @@ jobs:
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
-                python -m pip install -r requirements.txt
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "numpy${{ matrix.numpy-version }}"
+                python -m pip install -r requirements.txt
 
                 PYTHONPATH=$(pwd)/py:$PYTHONPATH PATH=$(pwd)/bin:$PATH install_redrock_templates -v ${RR_TEMPLATE_VER}
                 ### curl -L https://github.com/desihub/redrock-templates/archive/${RR_TEMPLATE_VER}.tar.gz | tar -x -z -v -C py/redrock

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10',]
+                python-version: ['3.10', '3.12']
                 numpy-version: ['<2.0', '>2.0']
                 # astropy-version: ['<3.0', '<4.1']  #, '<5.0']
         env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9', '3.10', '3.12']  # fitsio does not like Python < 3.7
+                python-version: ['3.9', '3.10']  # fitsio does not like Python < 3.7
                 numpy-version: ['<2.0', '>2.0']
                 # astropy-version: ['<3.0', '<4.1']  #, '<5.0']
         env:
@@ -35,7 +35,7 @@ jobs:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip wheel
+                python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9', '3.10']  # fitsio does not like Python < 3.7
+                python-version: ['3.10',]
                 numpy-version: ['<2.0', '>2.0']
                 # astropy-version: ['<3.0', '<4.1']  #, '<5.0']
         env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,8 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9', '3.10']  # fitsio does not like Python < 3.7
+                python-version: ['3.9', '3.10', '3.12']  # fitsio does not like Python < 3.7
+                numpy-version: ['<2.0', '>2.0']
                 # astropy-version: ['<3.0', '<4.1']  #, '<5.0']
         env:
             DESIUTIL_VERSION: 3.2.5
@@ -38,6 +39,8 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
+                python -m pip install --upgrade --upgrade-strategy only-if-needed "numpy${{ matrix.numpy-version }}"
+
                 PYTHONPATH=$(pwd)/py:$PYTHONPATH PATH=$(pwd)/bin:$PATH install_redrock_templates -v ${RR_TEMPLATE_VER}
                 ### curl -L https://github.com/desihub/redrock-templates/archive/${RR_TEMPLATE_VER}.tar.gz | tar -x -z -v -C py/redrock
                 ### /bin/mv py/redrock/redrock-templates-${RR_TEMPLATE_VER} py/redrock/data/templates

--- a/py/redrock/utils.py
+++ b/py/redrock/utils.py
@@ -31,12 +31,12 @@ def native_endian(data):
     Returns:
         array: original array if input in native endianness, otherwise a copy
             with the bytes swapped.
-
     """
     if data.dtype.isnative:
         return data
     else:
-        return data.byteswap().newbyteorder()
+        ### return data.byteswap().newbyteorder()  # only works with numpy<2
+        return data.byteswap().view(data.dtype.newbyteorder('native'))  # works with numpy 1.x or 2.x
 
 
 def encode_column(c):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-# Based on desimodules/22.2.
-numpy<2.0
+numpy
 astropy
 scipy
 h5py


### PR DESCRIPTION
This PR fixes `native_endian` to work with numpy 2.x, and adds numpy 2.x to the testing matrix (I hope ... apologies if I generate N>>1 emails getting the GitHub Actions sorted out).