### PR TITLE
Fix Rcsr usage with --allspec option

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -613,7 +613,7 @@ class DistTargetsDESI(DistTargets):
                             self._my_data[toff].spectra[tspec_res[t]].R = dia
                             #- Coadds replace Rcsr so only compute if not coadding
                             if not coadd and cache_Rcsr:
-                                self._my_data[toff].spectra[tspec_res[t]].Rcsr = dia.tocsr()
+                                self._my_data[toff].spectra[tspec_res[t]]._Rcsr = dia.tocsr()
                             tspec_res[t] += 1
                     toff += 1
 


### PR DESCRIPTION
This PR fixes issue #335 (crash when using --allspec) by setting `spectra._Rcsr` instead of `spectra.Rcsr` (which is a property view, not the actual variable).  The example from #335 now works:
```
$> rrdesi -i /global/cfs/cdirs/desi/users/ioannis/desimetals/paper1/spectra-paper1-loa.fits \
    -o $SCRATCH/redrock-spectra-paper1-loa.fits \
    --templates=/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/redrock-templates/main/rrtemplate-GALAXY-None-v2.6.fits \
    --zscan-galaxy=-0.005,0.5,1e-4 --allspec
...
Read and distribution of 28 targets: 0.6 seconds
Reading templates from ['/global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/redrock-templates/main/rrtemplate-GALAXY-None-v2.6.fits']
INFO: rrtemplate-GALAXY-None-v2.6.fits GALAXY  PCA IGM=Calura12 z=-0.005-0.4998
Read and broadcast of 1 templates: 0.0 seconds
Creating GPU context: 0.0 seconds
Rebinning templates: 7.5 seconds
Computing redshifts
  Scanning redshifts for template GALAXY
    Progress:   0 %
    Progress:  10 %
    Progress:  20 %
    Progress:  30 %
...
Writing /pscratch/sd/s/sjbailey/redrock-spectra-paper1-loa.fits took: 0.2 seconds
Total run time: 40.0 seconds
```