### PR TITLE
BAD_TARGET for OBJTYPE != SKY or TGT; also set z=0 for NODATA

### DIFF
--- a/py/redrock/external/desi.py
+++ b/py/redrock/external/desi.py
@@ -1117,6 +1117,7 @@ def rrdesi(options=None, comm=None):
             zfit['spectype'][ii] = 'GALAXY'
             zfit['subtype'][ii] = ''
             zfit['coeff'][ii] = 0.
+            zfit['z'][ii] = 0.
             # ADM enforce 4-string in case we've only populated PCA/NMF.
             zfit['fitmethod'] = zfit['fitmethod'].astype('U4')
             zfit['fitmethod'][ii] = 'NONE'


### PR DESCRIPTION
Addresses #224 and #328 
 Regarding 224, this issue has had a lot of on-and-off discussion across tickets over the past 2 years. The ideal solution would be to have a generic SPECTYPE for no-data cases, i.e., SPECTYPE=NONE instead of defaulting to galaxy. Defaulting to SPECTYPE=NONE, however, would crash several downstream processes so it should be approached with care. This PR only addresses setting Z=0 rather than solving that debate.