### PR TITLE
fix case of single template

### DIFF
--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -544,7 +544,7 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
                     tzfit2[k].append(val)
 
                 tzfit2[k] = np.vstack(tzfit2[k])
-                if (tzfit2[k].shape[1] == 1):
+                if (k != 'coeff') and (tzfit2[k].shape[1] == 1):
                     tzfit2[k] = tzfit2[k].flatten()
             tzfit = tzfit2
 
@@ -689,7 +689,7 @@ def zfind(targets, templates, mp_procs=1, nminima=3, archetypes=None, priors=Non
                 maxcoeff = max(np.max([t.template.nbasis for t in templates]), ncamera*(deg_legendre)+1)
 
         if allzfit['coeff'].ndim == 1:
-            ntarg = allzfit['coeff'].shape
+            ntarg = allzfit['coeff'].shape[0]
             ncoeff = 1
         else:
             ntarg, ncoeff = allzfit['coeff'].shape


### PR DESCRIPTION
This PR fixes #345.  Instead of recasting the 1D coeff column back to 2D, it fixes the upstream code that was incorrectly causing the 1D coeff column in the first place.  At the same time, if `allzfit['coeff'].ndim == 1` (maybe possible with archetypes?), then it was a bug anyway to have `ntarg = allzfit['coeff'].shape` instead of `ntarg = allzfit['coeff'].shape[0]`, so I fixed that here too.

## Tested that this produces the same answer as main for default templates
```
source /global/common/software/desi/desi_environment.sh main
cd /pscratch/sd/s/sjbailey/desi/redrock/template1
salloc -N 1 -C cpu -t 04:00:00 -q interactive

# main branch, standard templates
srun -n 64 rrdesi_mpi \
    --zscan-galaxy=1.2,1.3,1e-4 \
    -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/83582/20260116/coadd-4-83582-thru20260116.fits \
    -o redrock-main.fits \
    --templates /global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/redrock-templates/main/

# this branch, standard templates
module swap redrock/sjb
srun -n 64 rrdesi_mpi \
    --zscan-galaxy=1.2,1.3,1e-4 \
    -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/83582/20260116/coadd-4-83582-thru20260116.fits \
    -o redrock-branch.fits \
    --templates /global/common/software/desi/perlmutter/desiconda/20240425-2.2.0/code/redrock-templates/main/

# compare
fitsdiff redrock-main.fits redrock-branch.fits
```
--> bitwise identical for data, only differing in header timestamps and vesion tracking keywords

## fixes problem reported in #345 
```
srun -n 64 rrdesi_mpi \
    --zscan-galaxy=1.2,1.3,1e-4 \
    -i /global/cfs/cdirs/desi/spectro/redux/daily/tiles/cumulative/83582/20260116/coadd-4-83582-thru20260116.fits \
    -o redrock-lae.fits \
    --templates /global/cfs/cdirs/desicollab/users/rongpu/data/redrock/lae_templates_20260120
```
(note that compared to original report I restricted redshift range for faster testing of array dimensionality).