### PR TITLE
support numpy/2 and cupy/14 linalg.solve shape requirements

### DIFF
--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -1131,7 +1131,7 @@ def solve_matrices(M, y, solve_algorithm="PCA", solver_args=None, use_gpu=False)
         # For numpy/2.x and cupy 14.x, if M has dimensions (...,m,m) then y needs
         # dimensions (m,) or (..., m, k).
         # linalg.solve no longer supports M.shape=(...,m,m) and y.shape=(..., m),
-        # thus the reshaping logic which uses k=1 to temporarily update
+        # thus requiring reshaping logic with k=1 to temporarily update
         # y.shape = (...,m,1).
         # See https://github.com/cupy/cupy/pull/8629 and
         # https://numpy.org/doc/stable/reference/generated/numpy.linalg.solve.html#numpy.linalg.solve


### PR DESCRIPTION
Numpy/2.x and cupy/14.x changed the requirements on the allowable input shapes to `linalg.solve(M, y)`, leading to a `redrock.zscan.solve_matrices` crash when using cupy/14.x .  We had not caught this with previous numpy/2.x testing because the CPU path calls `solve_matrices` differently than the GPU path and thus didn't hit the API change.  Unit tests fail when running on GPUs at NERSC with cupy/14.x (DESI "test-main" environment); this PR fixes that by reshaping to have an extra dimension=1 and then re-reshaping.

Example
```
srun -N 1 -n 64 -c 2 --gpu-bind=map_gpu:3,2,1,0 --cpu-bind=cores \
    rrdesi_mpi --gpu --max-gpuprocs 4 \
    -i /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/test-26.2/tiles/cumulative/42508/20220612/coadd-0-42508-thru20220612.fits \
    -o $SCRATCH/desi/temp/redrock-0-42508-thru20220612.fits
```
calls `solve_matrices(M,y)` with `M.shape=(1446, 10, 10)` and `y.shape=(1446, 10)` which is then passed to `cp.linalg.solve(M,y)`.  Previously this was allowable, but now needs `y.shape=(1446,10,1)`.  I made the reshaping change internal to `solve_matrices` so that its API remains unchanged.

This update is required for Matterhorn.  I have verified that with the current desi main environment (numpy/1.22.4, cupy/13.1.0) this PR produces bitwise identical output as Redrock main.  With the new desi test-main environment (numpy/2.3.5, cupy/14.0.1), Redrock main crashes, while this PR produces output that differs by some rounding but no substantial differences compared out our current environment.

Background:
* https://numpy.org/doc/stable/reference/generated/numpy.linalg.solve.html#numpy.linalg.solve
* https://github.com/cupy/cupy/pull/8629